### PR TITLE
Allowing properties attribute for feature

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -71,7 +71,7 @@ export default class Layer extends Component {
   feature = (props, id) => ({
     type: "Feature",
     geometry: this.geometry(props.coordinates),
-    properties: { id }
+    properties: props.properties
   })
 
   onClick = evt => {


### PR DESCRIPTION
Hey there, first thanks for this project.
I was playing around the mapbox component and I realised that currently the `feature` method for build a `feature object` itself, inside the Layer component doesn't allow put the `properties` attribute, so there would be nice to have this custom functionality. So, for instance the `Feature` component will receive that new attribute in props. (ref to http://plnkr.co/edit/W7pfGHVBzJj8U3AmPyzf?p=preview)

If there is another way to do this please don't doubt on tell me. Cheers

```
          <Layer
            id="markers"
            type="symbol"
            layout={ {
              "icon-image": "{marker-symbol}-15",
              "text-field": "{title}",
              "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
              "text-offset": [0, 0.6],
              "text-anchor": "top"
            } }>
            {
              stations
                .map( ( station, index ) => (
                  <Feature
                    key={ station.get( 'id' ) }
                    properties={ {
                      "title": "Mapbox DC",
                      "marker-symbol": "monument"
                    } }
                    onHover={ this._onToggleHover.bind( null, 'pointer' ) }
                    onEndHover={ this._onToggleHover.bind( null, '' ) }
                    onClick={ this._markerClick.bind( null, station ) }
                    coordinates={ station.get( 'position' ) }/>
                ) ).toArray()
            }
          </Layer>
```