### PR TITLE
Removes duplicate state object and adds support for pitch property.

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -61,8 +61,6 @@ export default class ReactMapboxGl extends Component {
     map: this.state.map
   });
 
-  state = {};
-
   componentDidMount() {
     const {
       style,

--- a/src/map.js
+++ b/src/map.js
@@ -68,6 +68,7 @@ export default class ReactMapboxGl extends Component {
       preserveDrawingBuffer,
       accessToken,
       center,
+      pitch,
       zoom,
       minZoom,
       maxZoom,
@@ -98,6 +99,7 @@ export default class ReactMapboxGl extends Component {
       bearing,
       container: this.refs.mapboxContainer,
       center,
+      pitch,
       style,
       scrollZoom
     });


### PR DESCRIPTION
![image](https://i.imgur.com/h4ZBhlP.png)

Allows user to pass in a 'pitch' properly so that the map can be tilted on initial load. More info in [MapBox Javascript GL API docs](https://www.mapbox.com/mapbox-gl-js/api/#Map).

Example usage:

```
state = {
    center: [-0.109970527, 51.52916347],
    pitch: [60],  // Angle in degress to tilt map. Max === 60.
    zoom: [11],
    skip: 0,
    stations: new Map(),
    popupShowLabel: true
};

render() {
    return (
        <div className="map-container">
            <ReactMapboxGl
                style={style}
                center={this.state.center}
                zoom={this.state.zoom}
                pitch={this.state.pitch}
                minZoom={8}
                maxZoom={15}
                maxBounds={maxBounds}
                accessToken={accessToken}
                onDrag={this._onDrag}
                onMoveEnd={this._setMove.bind(this, true)}
                onMove={this._setMove.bind(this, false)}
                containerStyle={containerStyle}
            />
        </div>
    )
}
```