### PR TITLE
Add support for AttributionControl position

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -32,6 +32,11 @@ import ReactMapboxGl from "react-mapbox-gl";
   - `jumpTo`
   - `easeTo`
   - `flyTo`
+- **attributionPosition**: `String` The corner of the map to include the mandatory Mapbox attribution. Possible values:
+  - `top-left`
+  - `top-right`
+  - `bottom-left`
+  - `bottom-right`
 - **onClick**: `Function` : Triggered whenever user click on the map
   - Function::(map: Object, event: Object)
 - **onStyleLoad**: `Function` : Listener of Mapbox event : `map.on("style.load")`

--- a/src/map.js
+++ b/src/map.js
@@ -35,6 +35,12 @@ export default class ReactMapboxGl extends Component {
       "jumpTo",
       "easeTo",
       "flyTo"
+    ]),
+    attributionPosition: PropTypes.oneOf([
+      "top-left",
+      "top-right",
+      "bottom-left",
+      "bottom-right"
     ])
   };
 
@@ -51,7 +57,8 @@ export default class ReactMapboxGl extends Component {
     bearing: 0,
     scrollZoom: true,
     movingMethod: "flyTo",
-    pitch: 0
+    pitch: 0,
+    attributionPosition: 'bottom-right'
   };
 
   static childContextTypes = {
@@ -87,7 +94,8 @@ export default class ReactMapboxGl extends Component {
       onMoveStart,
       onMoveEnd,
       onZoom,
-      scrollZoom
+      scrollZoom,
+      attributionPosition
     } = this.props;
 
     MapboxGl.accessToken = accessToken;
@@ -104,7 +112,10 @@ export default class ReactMapboxGl extends Component {
       center,
       pitch,
       style,
-      scrollZoom
+      scrollZoom,
+      attributionControl: {
+        position: attributionPosition
+      }
     });
 
     map.on("style.load", (...args) => {


### PR DESCRIPTION
Hi!

In a personal project, I needed to position the mapbox attribution in the top-right corner, instead of the bottom-right. So I added it as a prop. 

No worries if you're not interested in accepting this PR, but I thought I'd open it in case others could benefit.

The implementation was pretty straightforward. The only bit I'm unsure of is whether it's best to have an `attributionPosition` prop (as I've done), or to mirror the official API more closely with an `attributionControl` prop that takes an object.

I've opted for simplicity over accuracy, but let me know if it should be flipped :)