### PR TITLE
Compare primitive data types for camera options

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -217,19 +217,19 @@ export default class ReactMapboxGl extends Component {
     const bearing = map.getBearing();
 
     const didZoomUpdate = (
-      this.props.zoom !== nextProps.zoom &&
-      nextProps.zoom !== map.getZoom()
+      this.props.zoom[0] !== nextProps.zoom[0] &&
+      nextProps.zoom[0] !== map.getZoom()
     );
 
     const didCenterUpdate = (
-      this.props.center !== nextProps.center &&
-      nextProps.center !== map.getCenter()
+      (this.props.center[0] !== nextProps.center[0] || this.props.center[1] !== nextProps.center[1]) &&
+      (nextProps.center[0] !== map.getCenter().lng || nextProps.center[1] !== map.getCenter().lat)
     );
 
     const didBearingUpdate = (
       this.props.bearing !== nextProps.bearing &&
       nextProps.bearing !== map.getBearing()
-    )
+    );
 
     if (didZoomUpdate || didCenterUpdate || didBearingUpdate) {
       map[this.props.movingMethod]({


### PR DESCRIPTION
When I was using the component with redux together the zoom array and the center object where recreated although the camera option values haven't changed.

My solution was to compare the primitive data types instead of the composite data types inside the `componentWillReceiveProps` method.

Also the comparisons `nextProps.zoom !== map.getZoom()` and `nextProps.center !== map.getCenter()` were comparing differently structured data types.