### PR TITLE
Feature/improve camera options comparison (with reference comparison)

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -217,12 +217,12 @@ export default class ReactMapboxGl extends Component {
     const bearing = map.getBearing();
 
     const didZoomUpdate = (
-      this.props.zoom[0] !== nextProps.zoom[0] &&
+      this.props.zoom !== nextProps.zoom &&
       nextProps.zoom[0] !== map.getZoom()
     );
 
     const didCenterUpdate = (
-      (this.props.center[0] !== nextProps.center[0] || this.props.center[1] !== nextProps.center[1]) &&
+      this.props.center !== nextProps.center &&
       (nextProps.center[0] !== map.getCenter().lng || nextProps.center[1] !== map.getCenter().lat)
     );
 

--- a/src/map.js
+++ b/src/map.js
@@ -217,19 +217,19 @@ export default class ReactMapboxGl extends Component {
     const bearing = map.getBearing();
 
     const didZoomUpdate = (
-      this.props.zoom !== nextProps.zoom &&
-      nextProps.zoom !== map.getZoom()
+      this.props.zoom[0] !== nextProps.zoom[0] &&
+      nextProps.zoom[0] !== map.getZoom()
     );
 
     const didCenterUpdate = (
-      this.props.center !== nextProps.center &&
-      nextProps.center !== map.getCenter()
+      (this.props.center[0] !== nextProps.center[0] || this.props.center[1] !== nextProps.center[1]) &&
+      (nextProps.center[0] !== map.getCenter().lng || nextProps.center[1] !== map.getCenter().lat)
     );
 
     const didBearingUpdate = (
       this.props.bearing !== nextProps.bearing &&
       nextProps.bearing !== map.getBearing()
-    )
+    );
 
     if (didZoomUpdate || didCenterUpdate || didBearingUpdate) {
       map[this.props.movingMethod]({


### PR DESCRIPTION
The comparison of this.props and nextProps uses reference comparison now. For comparing the current map camera options with the corresponding nextProps properties, primitive data types are compared.