### PR TITLE
Re-worked Popup and Marker to be regular react component

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -223,11 +223,6 @@ import { ScaleControl } from "react-mapbox-gl";
 # Popup
 
 The popup component allow you to display a popup tooltip on top of the map using mapbox-gl-js.
-You can define the content of the popup by using react component, it will be rendered as a DOM element using react-dom and injected in the popup.
-
-### Disclaimer
-
-As the children components of the popup are rendered using `ReactDOM.render`, you can't pass down a context.
 
 ### Import
 
@@ -237,10 +232,6 @@ import { Popup } from "react-mapbox-gl";
 
 ### Properties
 - **coordinates** *(required)*: `Array of Number` Display the popup at the given position.
-- **dangerouslySetInnerHTML**: `String` Set the content of the popup using string.
-- **text**: `String` Set the text content of the popup
-- **closeButton**: `Boolean` Add a cross button to close the popup
-- **closeOnClick**: `Boolean` Close the popup in click on it
 - **anchor**: `String` Set the anchor point of the popup, Possible values :
   - `top`
   - `bottom`
@@ -250,12 +241,21 @@ import { Popup } from "react-mapbox-gl";
   - `top-right`
   - `bottom-left`
   - `bottom-right`
+  - `null | undefined`: When not set, the anchor is automatically calculated to keep the content of the popup visible. 
+- **offset** *(Default: 0)*: `Number | Array<Number> | Object` Set the offset of popup, where the tip of the popup will be pointing.
+  - When `Number` is passed, the popup will be offset by that number for all anchor positions.
+  - When an `Array<Number>` is passed (e.g. [-12, 30]), the popup will be offset by that point.
+  - When `Object` is passed, it must contain keys for different anchor positions and values as the offset (`Number` or `Array<Number>`)
 
 
 ### Example
 
 ```
-<Popup coordinates={[-0.13235092163085938,51.518250335096376]}>
+<Popup 
+  coordinates={[-0.13235092163085938,51.518250335096376]}
+  offset={{
+    'bottom-left': [12, -38],  'bottom': [0, -38], 'bottom-right': [-12, -38]
+  }}>
   <h1>Popup</h1>
 </Popup>
 ```
@@ -273,20 +273,15 @@ import { Marker } from "react-mapbox-gl";
 
 ### Properties
 - **coordinates** *(required)*: `Array of Number` Display the popup at the given position.
-- **container**: `DOMElement` Use the given DOM element to render the children components in.
+- **anchor**: `String` Same as Popup's anchor property.
+- **offset**: `String` Same as Popup's offset property.
 
 ### Example
 
 ```
-const markerContainer = document.createElement('div');
-markerContainer.style.width = "400px";
-markerContainer.style.position = "absolute";
-
-...
-
 <Marker
-  container={markerContainer}
-  coordinates={[-0.2416815, 51.5285582]}>
-    <h1>TEST</h1>
+  coordinates={[-0.2416815, 51.5285582]}
+  anchor="bottom">
+  <img src={markerUrl}/>
 </Marker>
 ```

--- a/src/constants/css.js
+++ b/src/constants/css.js
@@ -96,6 +96,15 @@ export default `
       margin-left: 2px;
   }
 
+  .mapboxgl-marker {
+      position: absolute;
+      top: 0;
+      left: 0;
+      display: -webkit-flex;
+      display: flex;
+      will-change: transform;
+  }
+
   .mapboxgl-popup {
       position: absolute;
       top: 0;
@@ -105,6 +114,7 @@ export default `
       will-change: transform;
       pointer-events: none;
   }
+  .mapboxgl-popup-anchor-center,
   .mapboxgl-popup-anchor-top,
   .mapboxgl-popup-anchor-top-left,
   .mapboxgl-popup-anchor-top-right {
@@ -130,6 +140,9 @@ export default `
       height: 0;
       border: 10px solid transparent;
       z-index: 1;
+  }
+  .mapboxgl-popup-anchor-center .mapboxgl-popup-tip {
+      display: none;
   }
   .mapboxgl-popup-anchor-top .mapboxgl-popup-tip {
       -webkit-align-self: center;

--- a/src/marker.js
+++ b/src/marker.js
@@ -24,6 +24,10 @@ export default class Marker extends React.Component {
   state = {
   }
 
+  setContainer = (el) => {
+    this.container = el;
+  }
+
   handleMapMove = () => {
     this.setState(overlayState(this.props, this.context, this.container));
   }
@@ -56,7 +60,7 @@ export default class Marker extends React.Component {
       <div className="mapboxgl-marker"
            onClick={onClick}
            style={style}
-           ref={(el) => { this.container = el; }}>
+           ref={this.setContainer}>
         {this.props.children}
       </div>
     );

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,11 +1,13 @@
 import React, { PropTypes } from 'react';
 import {
+  anchorPropTypes,
+  offsetPropTypes,
   projectCoordinates,
   anchorTranslate,
   positionTranslate,
   calculateAnchor,
-  normalizeOffset,
-} from './util/popup';
+  normalizeOffsets,
+} from './util/overlays';
 
 export default class Popup extends React.Component {
   static contextTypes = {
@@ -17,25 +19,13 @@ export default class Popup extends React.Component {
     children: PropTypes.node,
     closeButton: PropTypes.bool,
     closeOnClick: PropTypes.bool,
-    anchor: PropTypes.oneOf([
-      'top',
-      'bottom',
-      'left',
-      'right',
-      'top-left',
-      'top-right',
-      'bottom-left',
-      'bottom-right',
-    ]),
-    offset: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.object,
-    ]),
+    anchor: anchorPropTypes,
+    offset: offsetPropTypes,
   }
 
   static defaultProps = {
-    closeButton: true,
-    closeOnClick: true,
+    closeButton: false,
+    closeOnClick: false,
     offset: 0,
   }
 
@@ -51,7 +41,7 @@ export default class Popup extends React.Component {
     const { map } = this.context;
 
     const pos = projectCoordinates(map, this.props.coordinates);
-    const offsets = normalizeOffset(this.props.offset);
+    const offsets = normalizeOffsets(this.props.offset);
     const anchor = this.props.anchor
       || calculateAnchor(map, offsets, pos, { offsetWidth, offsetHeight });
 
@@ -93,9 +83,13 @@ export default class Popup extends React.Component {
   render() {
     const closeButton = <button type="button" className="mapboxgl-popup-close-button" onClick={this.handleClickClose}>&#215;</button>;
     const { anchor, position } = this.state;
+    const style = {
+      transform: `${anchorTranslate(anchor)} ${positionTranslate(position)}`,
+      zIndex: 3,
+    };
     return (
       <div className={`mapboxgl-popup mapboxgl-popup-anchor-${anchor}`}
-           style={{ transform: `${anchorTranslate(anchor)} ${positionTranslate(position)}`, zIndex: 2 }}
+           style={style}
            ref={(el) => { this.container = el; }}>
         <div className="mapboxgl-popup-tip"></div>
         <div className="mapboxgl-popup-content">

--- a/src/popup.js
+++ b/src/popup.js
@@ -24,6 +24,10 @@ export default class Popup extends React.Component {
   state = {
   }
 
+  setContainer = (el) => {
+    this.container = el;
+  }
+
   handleMapMove = () => {
     this.setState(overlayState(this.props, this.context, this.container));
   }
@@ -53,9 +57,9 @@ export default class Popup extends React.Component {
   render() {
     const { anchor } = this.state;
     return (
-      <div className={`mapboxgl-popup mapboxgl-popup-anchor-${anchor || ''}`}
+      <div className={`mapboxgl-popup ${anchor ? `mapboxgl-popup-anchor-${anchor}` : ''}`}
            style={{ transform: overlayTransform(this.state), zIndex: 3 }}
-           ref={(el) => { this.container = el; }}>
+           ref={this.setContainer}>
         <div className="mapboxgl-popup-tip"></div>
         <div className="mapboxgl-popup-content">
           {this.props.children}

--- a/src/scale-control.js
+++ b/src/scale-control.js
@@ -19,7 +19,7 @@ const positions = {
 
 const containerStyle = {
   position: 'absolute',
-  zIndex: 2,
+  zIndex: 10,
   boxShadow: '0px 1px 4px rgba(0, 0, 0, .3)',
   border: '1px solid rgba(0, 0, 0, 0.1)',
   right: 50,

--- a/src/util/overlays.js
+++ b/src/util/overlays.js
@@ -30,9 +30,9 @@ const projectCoordinates = (map, coordinates) =>
 const calculateAnchor = (map, offsets, position, { offsetHeight, offsetWidth }) => {
   let anchor = null;
 
-  if (position.y + offsets.bottom.y < offsetHeight) {
+  if (position.y + offsets.bottom.y - offsetHeight < 0) {
     anchor = ['top'];
-  } else if (position.y > map.transform.height - offsetHeight) {
+  } else if (position.y + offsets.top.y + offsetHeight > map.transform.height) {
     anchor = ['bottom'];
   } else {
     anchor = [];

--- a/src/util/popup.js
+++ b/src/util/popup.js
@@ -1,0 +1,96 @@
+/* eslint quote-props: 0 */
+/* eslint dot-notation: 0 */
+/* eslint no-else-return: 0 */
+
+import { LngLat, Point } from 'mapbox-gl/dist/mapbox-gl.js';
+
+export const projectCoordinates = (map, coordinates) =>
+  map.project(LngLat.convert(coordinates)).round();
+
+export const anchorTranslate = (anchor) => {
+  const anchorTranslates = {
+    'top': 'translate(-50%,0)',
+    'top-left': 'translate(0,0)',
+    'top-right': 'translate(-100%,0)',
+    'bottom': 'translate(-50%,-100%)',
+    'bottom-left': 'translate(0,-100%)',
+    'bottom-right': 'translate(-100%,-100%)',
+    'left': 'translate(0,-50%)',
+    'right': 'translate(-100%,-50%)',
+  };
+  return anchorTranslates[anchor];
+};
+
+export const positionTranslate = position => `translate(${position.x}px,${position.y}px)`;
+
+export const calculateAnchor = (map, offsets, pos, { offsetHeight, offsetWidth }) => {
+  let anchor = null;
+
+  if (pos.y + offsets.bottom.y < offsetHeight) {
+    anchor = ['top'];
+  } else if (pos.y > map.transform.height - offsetHeight) {
+    anchor = ['bottom'];
+  } else {
+    anchor = [];
+  }
+
+  if (pos.x < offsetWidth / 2) {
+    anchor.push('left');
+  } else if (pos.x > map.transform.width - offsetWidth / 2) {
+    anchor.push('right');
+  }
+
+  if (anchor.length === 0) {
+    anchor = 'bottom';
+  } else {
+    anchor = anchor.join('-');
+  }
+  return anchor;
+};
+
+const isPointLike = input => input instanceof Point || Array.isArray(input);
+
+export const normalizeOffset = (offset) => {
+  if (!offset) {
+    return normalizeOffset(new Point(0, 0));
+  } else if (typeof offset === 'number') {
+    // input specifies a radius from which to calculate offsets at all positions
+    const cornerOffset = Math.round(Math.sqrt(0.5 * Math.pow(offset, 2)));
+    return {
+      'top': new Point(0, offset),
+      'top-left': new Point(cornerOffset, cornerOffset),
+      'top-right': new Point(-cornerOffset, cornerOffset),
+      'bottom': new Point(0, -offset),
+      'bottom-left': new Point(cornerOffset, -cornerOffset),
+      'bottom-right': new Point(-cornerOffset, -cornerOffset),
+      'left': new Point(offset, 0),
+      'right': new Point(-offset, 0),
+    };
+  } else if (isPointLike(offset)) {
+    // input specifies a single offset to be applied to all positions
+    const convertedOffset = Point.convert(offset);
+    return {
+      'top': convertedOffset,
+      'top-left': convertedOffset,
+      'top-right': convertedOffset,
+      'bottom': convertedOffset,
+      'bottom-left': convertedOffset,
+      'bottom-right': convertedOffset,
+      'left': convertedOffset,
+      'right': convertedOffset,
+    };
+  } else {
+    // input specifies an offset per position
+    return {
+      'top': Point.convert(offset['top']),
+      'top-left': Point.convert(offset['top-left']),
+      'top-right': Point.convert(offset['top-right']),
+      'bottom': Point.convert(offset['bottom']),
+      'bottom-left': Point.convert(offset['bottom-left']),
+      'bottom-right': Point.convert(offset['bottom-right']),
+      'left': Point.convert(offset['left']),
+      'right': Point.convert(offset['right']),
+    };
+  }
+};
+

--- a/src/zoom-control.js
+++ b/src/zoom-control.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 
 const containerStyle = {
   position: 'absolute',
-  zIndex: 2,
+  zIndex: 10,
   display: 'flex',
   flexDirection: 'column',
   boxShadow: '0px 1px 4px rgba(0, 0, 0, .3)',


### PR DESCRIPTION
relevalnt logic borrowed from MapboxGL.Popup.

There are breaking changes in the API for Marker and Popup components, notably Popup's closeButton and closeOnClick properties are gone. It's now trivial to add any content to a popup, and the state management (if popup is open, or has close button and its style) are better left for the consumer of the library.

Example: 
```javascript
        <ReactMapboxGl
          {...this.staticMapboxGlProps}
          center={this.state.center || center}
          containerStyle={mapContainerStyle(this.props) }
          onZoom={this.handleZoomChange}
          onMoveStart={this.handleMoveStart}
          onMoveEnd={this.handleMoveEnd}
          onDrag={this.handleDrag}
          onDragEnd={this.handleDragEnd}>

          <ZoomControl zoomDiff={1}/>

          { // Display the markers
            stores && stores.map((store, index) => (
                <Marker
                  key={store.id}
                  coordinates={[store.coordinates.longitude, store.coordinates.latitude]}
                  anchor="bottom"
                  onClick={() => this.handleMarkerClick(store)}>
                  <img src={defaultPin}/>
                </Marker>
              )
            )
          }

          { // Display the popups
            selectedStore &&
            <Popup
              coordinates={[selectedStore.coordinates.longitude, selectedStore.coordinates.latitude]}
              offset={{
                'bottom-left': [12, -38],  'bottom': [0, -38], 'bottom-right': [-12, -38], 'right': [0, 0],
                'top-right': [0, 0], 'top': [0, 0], 'top-left': [0, 0], 'left': [0, 0]
              }}>
              <div>
                 <Heading component="h3">{store.name}</Heading>
                 <a className="button-close" onClick={this.handleClosePopup}>&times;</a>
              </div>
            </Popup>
          }
        </ReactMapboxGl>
```
