### PR TITLE
Animated zoom

### DIFF
--- a/src/zoom-control.js
+++ b/src/zoom-control.js
@@ -62,7 +62,7 @@ export default class ZoomControl extends Component {
     position: POSITIONS[0],
     zoomDiff: 0.5,
     onControlClick: (map, zoomDiff) => {
-      map.setZoom(map.getZoom() + zoomDiff);
+      map.zoomTo(map.getZoom() + zoomDiff);
     },
   };
 


### PR DESCRIPTION
Fixes #76 in which the `ZoomControl` component wasn't respecting Mapbox's movingMethod and zooming was jumpy instead of animated by default.