### PR TITLE
fix name of marker class

### DIFF
--- a/src/marker.js
+++ b/src/marker.js
@@ -6,7 +6,7 @@ import {
 
 const propsToRemove = { children: undefined };
 
-export default class Popup extends React.Component {
+export default class Marker extends React.Component {
   static propTypes = {
     coordinates: PropTypes.arrayOf(PropTypes.number).isRequired,
     anchor: OverlayPropTypes.anchor,


### PR DESCRIPTION
just noticed this change as a result of https://github.com/alex3165/react-mapbox-gl/commit/4f7a4ddac7a34f38fc78e25ba5c4d2cdbd3fdbe1 and I think you meant to keep the name `Marker`. 

thanks! 