### PR TITLE
raster layer enabled and source component

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The library include the following elements :
 - ZoomControl
 - ScaleControl
 - Popup
+- Source
 
 ## How to start
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The library include the following elements :
 
 - ReactMapboxGl
 - Layer
+- Source
 - GeoJSONLayer
 - Marker (Html marker)
 - Feature
@@ -17,7 +18,6 @@ The library include the following elements :
 - ZoomControl
 - ScaleControl
 - Popup
-- Source
 
 ## How to start
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,6 +103,36 @@ import { Layer } from "react-mapbox-gl";
 ```
 
 ----------
+# Source
+
+Add a source to the map (for layers to use, for example).
+
+### Import
+
+```
+import { Source } from "react-mapbox-gl";
+```
+
+### Properties
+- **id** *(required)*: `String`
+- **options** *(required)*: `Object` Source options.
+
+### Example
+
+```
+const RASTER_SOURCE_OPTIONS = {
+  "type": "raster",
+  "tiles": [
+    "https://someurl.com/512/{z}/{x}/{y}",
+  ],
+  "tileSize": 512,
+  data: {},
+};
+<Source id="example_id" sourceOptions={RASTER_SOURCE_OPTIONS} />
+<Layer type="raster" id="example_id" sourceId="example_id" />
+```
+
+----------
 # GeoJSONLayer
 
 Display on the map all the informations contained in a geojson file.
@@ -289,32 +319,4 @@ import { Marker } from "react-mapbox-gl";
   anchor="bottom">
   <img src={markerUrl}/>
 </Marker>
-```
-# Source
-
-Add a source to the map (for layers to use, for example).
-
-### Import
-
-```
-import { Source } from "react-mapbox-gl";
-```
-
-### Properties
-- **id** *(required)*: `String`
-- **options** *(required)*: `Object` Source options.
-
-### Example
-
-```
-const RASTER_SOURCE_OPTIONS = {
-  "type": "raster",
-  "tiles": [
-    "https://someurl.com/512/{z}/{x}/{y}",
-  ],
-  "tileSize": 512,
-  data: {},
-};
-<Source id="example_id" sourceOptions={RASTER_SOURCE_OPTIONS} />
-<Layer type="raster" id="example_id" sourceId="example_id" />
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,7 +54,7 @@ import ReactMapboxGl from "react-mapbox-gl";
   - Function::(map: Object, event: Object)
 - **onZoom**: `Function` : Executed repeatedly during transitions between zoom levels
   - Function::(map: Object, event: Object)
-- **dragRotate** *(Default: `true`)*: `Boolean` Set to `false` to disable drag rotation, see [mapbox DragRotateHandler](https://www.mapbox.com/mapbox-gl-js/api/#DragRotateHandler) 
+- **dragRotate** *(Default: `true`)*: `Boolean` Set to `false` to disable drag rotation, see [mapbox DragRotateHandler](https://www.mapbox.com/mapbox-gl-js/api/#DragRotateHandler)
 
 ### Example
 
@@ -85,6 +85,7 @@ import { Layer } from "react-mapbox-gl";
   - `line`, Include a Mapbox `line` (`LineString` GeoJson)
   - `fill`, Include a Mapbox `polygon` (`Fill` GeoJson)
   - `circle`, Include a Mapbox `circle` (`Point` GeoJson)
+  - `raster`, Include a Mapbox raster layer
 - **layout**: Mapbox layout object passed down to mapbox `addLayer` method [mapbox layout api](https://www.mapbox.com/mapbox-gl-style-spec/#layer-layout)
 - **paint**: Mapbox paint object passed down to mapbox `addLayer` method [mapbox paint api](https://www.mapbox.com/mapbox-gl-style-spec/#layer-paint)
 - **sourceOptions**: Options object merged to the object used when calling `GeoJSONSource` method
@@ -288,4 +289,32 @@ import { Marker } from "react-mapbox-gl";
   anchor="bottom">
   <img src={markerUrl}/>
 </Marker>
+```
+# Source
+
+Add a source to the map (for layers to use, for example).
+
+### Import
+
+```
+import { Source } from "react-mapbox-gl";
+```
+
+### Properties
+- **id** *(required)*: `String`
+- **options** *(required)*: `Object` Source options.
+
+### Example
+
+```
+const RASTER_SOURCE_OPTIONS = {
+  "type": "raster",
+  "tiles": [
+    "https://someurl.com/512/{z}/{x}/{y}",
+  ],
+  "tileSize": 512,
+  data: {},
+};
+<Source id="example_id" sourceOptions={RASTER_SOURCE_OPTIONS} />
+<Layer type="raster" id="example_id" sourceId="example_id" />
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import ZoomControl from './zoom-control';
 import Popup from './popup';
 import ScaleControl from './scale-control';
 import Marker from './marker';
+import Source from './source';
 
 injectCSS(window);
 
@@ -20,6 +21,7 @@ export {
   ZoomControl,
   ScaleControl,
   Marker,
+  Source,
 };
 
 export default Map;

--- a/src/layer.js
+++ b/src/layer.js
@@ -22,6 +22,7 @@ export default class Layer extends React.PureComponent {
       'line',
       'fill',
       'circle',
+      'raster',
     ]),
 
     layout: PropTypes.object,

--- a/src/source.js
+++ b/src/source.js
@@ -2,10 +2,6 @@ import React, { PropTypes } from 'react';
 
 export default class Source extends React.Component {
 
-  render() {
-    return null;
-  };
-
   static contextTypes = {
     map: PropTypes.object,
   };
@@ -34,4 +30,9 @@ export default class Source extends React.Component {
       map.removeSource(this.id);
     }
   }
+
+  render() {
+    return null;
+  };
+
 }

--- a/src/source.js
+++ b/src/source.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react';
+
+export default class Source extends React.Component {
+
+  render() {
+    return null;
+  };
+
+  static contextTypes = {
+    map: PropTypes.object,
+  };
+
+  static propTypes = {
+    id: PropTypes.string,
+    sourceOptions: PropTypes.object,
+  };
+
+  id = this.props.id;
+
+  source = {
+    ...this.props.sourceOptions,
+  }
+
+  componentWillMount() {
+    const { map } = this.context;
+    if (!map.getSource(this.id)) {
+      map.addSource(this.id, this.source);
+    }
+  }
+
+  componentWillUnmount() {
+    const { map } = this.context;
+    if (map.getSource(this.id)) {
+      map.removeSOurce(this.id);
+    }
+  }
+}

--- a/src/source.js
+++ b/src/source.js
@@ -11,7 +11,7 @@ export default class Source extends React.Component {
   };
 
   static propTypes = {
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
     sourceOptions: PropTypes.object,
   };
 
@@ -31,7 +31,7 @@ export default class Source extends React.Component {
   componentWillUnmount() {
     const { map } = this.context;
     if (map.getSource(this.id)) {
-      map.removeSOurce(this.id);
+      map.removeSource(this.id);
     }
   }
 }


### PR DESCRIPTION
This PR makes it so that the following is valid:

```
<Source id="example_id" sourceOptions={RASTER_SOURCE_OPTIONS} />
<Layer type="raster" id="example_id" sourceId="example_id" />`
```

Will add documentation before merging but wanted to put this up for public scrutiny.