### PR TITLE
Source component should respond to sourceOptions.data updates

### DIFF
--- a/src/source.js
+++ b/src/source.js
@@ -31,6 +31,22 @@ export default class Source extends React.Component {
     }
   }
 
+  componentWillReceiveProps(props) {
+    const { id } = this;
+    const { sourceOptions } = this.props;
+    const { map } = this.context;
+
+    if (props.sourceOptions.data !== sourceOptions.data) {
+      map
+        .getSource(id)
+        .setData(props.sourceOptions.data);
+    }
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return nextProps.sourceOptions.data !== this.props.sourceOptions.data;
+  }
+
   render() {
     return null;
   }


### PR DESCRIPTION
Right now if you create a `<Source>` component with GeoJSON data, the data can't be updated after the component is mounted.

This would allow you to update the GeoJSON data e.g. `<Source id="source-id" sourceOptions={{type: 'geojson', data: geojsonData}}>` and have mapbox-gl re-render when the data changes.