### PR TITLE
call setData when children disappear

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -208,20 +208,17 @@ export default class Layer extends React.PureComponent<Props, void> {
 
   public render() {
     const { map } = this.context;
+    const children = ([] as any).concat(this.props.children || []);
 
-    if (this.props.children) {
-      const children = ([] as any).concat(this.props.children);
+    const features = children
+      .map(({ props }: any, id: string) => this.makeFeature(props, id))
+      .filter(Boolean);
 
-      const features = children
-        .map(({ props }: any, id: string) => this.makeFeature(props, id))
-        .filter(Boolean);
-
-      const source = map.getSource(this.props.sourceId || this.id);
-      (source as MapboxGL.GeoJSONSource).setData({
-        type: 'FeatureCollection',
-        features
-      });
-    }
+    const source = map.getSource(this.props.sourceId || this.id);
+    (source as MapboxGL.GeoJSONSource).setData({
+      type: 'FeatureCollection',
+      features
+    });
 
     return null;
   }


### PR DESCRIPTION
Previously, if you had a Layer that had Features as children,
and then the props changed such that the Layer no longer had
children, <source>.setData would not be called to remove the
Features from the source.

To fix this, I've changed Layer so that it will always call
setData when rendered. This should be fine because Layer#render
will only be called if the component should update.

I've added tests as well.