### PR TITLE
Fix bug in source data not being loaded by geojson source

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -112,6 +112,7 @@ import { Source } from "react-mapbox-gl";
 - **geoJsonSource** : `Object` GeoJson source, see [mapbox-gl GeoJson](https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-geojson) for options
 - **tileJsonSource** : `Object` TileJson source, see [mapbox-gl TileJson](https://www.mapbox.com/mapbox-gl-js/style-spec/#sources) for options
 - **onSourceAdded** : `Function` Executed once the source is added to the map, the source is passed as a first argument.
+- **onSourceLoaded** : `Function` Executed once the source data has been loaded for the first time (after [mapbox-gl map.event:load](https://www.mapbox.com/mapbox-gl-js/api/#map.event:load)), the source is passed as a first argument.
 
 ### Example
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "tsx",
       "js"
     ],
+    "browser": true,
     "verbose": true
   },
   "files": [

--- a/src/__tests__/layer.test.tsx
+++ b/src/__tests__/layer.test.tsx
@@ -78,7 +78,7 @@ describe('Layer', () => {
         'properties': {id: 0},
         'type': 'Feature'
       }]
-    }])
+    }]);
   });
 
   it('Should set features to empty array when children disappear', () => {
@@ -93,6 +93,6 @@ describe('Layer', () => {
     expect(setDataMock.mock.calls[1]).toEqual([{
       'type': 'FeatureCollection',
       'features': []
-    }])
+    }]);
   });
 });

--- a/src/__tests__/source.test.tsx
+++ b/src/__tests__/source.test.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import Source from '../source';
+import { withContext } from 'recompose';
+import { mount } from 'enzyme';
+
+const EMPTY_GEOJSON = {
+  'type': 'FeatureCollection',
+  'features': []
+};
+
+const EMPTY_GEOJSON_SRC = {
+  type: 'geojson',
+  data: EMPTY_GEOJSON
+};
+
+describe('Source', () => {
+  let SourceWithContext: any;
+  let addSourceMock: any;
+  let removeSourceMock: any;
+  let setDataMock: any;
+  let children: any[];
+  let childrenWithOneFeature: any[];
+  let feature: object;
+
+  beforeEach(() => {
+    addSourceMock = jest.fn();
+    removeSourceMock = jest.fn();
+    setDataMock = jest.fn();
+    feature = { coordinates: [-123, 45] };
+    children = [{ props: {} }];
+    childrenWithOneFeature = [{ props: feature }];
+
+    SourceWithContext = withContext({
+      map: React.PropTypes.object
+    }, () => ({
+      map: {
+        addSource: addSourceMock,
+        removeSource: removeSourceMock,
+        on: jest.fn(),
+        off: jest.fn(),
+        getSource: jest.fn(() => this.id)
+      }
+    }))(Source);
+  });
+
+  it('Should render source with default options', () => {
+    mount(
+      <SourceWithContext
+        id="source-1"
+        geoJsonSource={EMPTY_GEOJSON_SRC}
+      /> as React.ReactElement<any>
+    );
+    console.log('addSourceMock.mock.calls', addSourceMock.mock.calls);
+    expect(addSourceMock.mock.calls[0]).toEqual(['source-1', {
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: []
+      }
+    }]);
+  });
+
+  it('Should render source with default source', () => {
+    mount(
+      <SourceWithContext
+        children={children}
+      /> as React.ReactElement<any>
+    );
+
+    expect(addSourceMock.mock.calls[0]).toEqual(['source-2', {
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: []
+      }
+    }]);
+  });
+
+  it('Should set features based on children', () => {
+    const source = mount(
+      <SourceWithContext
+        children={childrenWithOneFeature}
+      /> as React.ReactElement<any>
+    );
+
+    expect(setDataMock.mock.calls[0]).toEqual([{
+      'type': 'FeatureCollection',
+      'features': [{
+        'geometry': { ...feature, 'type': 'Point' },
+        'properties': { id: 0 },
+        'type': 'Feature'
+      }]
+    }]);
+  });
+
+  it('Should set features to empty array when children disappear', () => {
+    const source = mount(
+      <SourceWithContext
+        children={childrenWithOneFeature}
+      /> as React.ReactElement<any>
+    );
+
+    source.setProps({ children: undefined });
+
+    expect(setDataMock.mock.calls[1]).toEqual([{
+      'type': 'FeatureCollection',
+      'features': []
+    }]);
+  });
+});

--- a/src/__tests__/source.test.tsx
+++ b/src/__tests__/source.test.tsx
@@ -3,32 +3,25 @@ import Source from '../source';
 import { withContext } from 'recompose';
 import { mount } from 'enzyme';
 
-const EMPTY_GEOJSON = {
-  'type': 'FeatureCollection',
-  'features': []
-};
-
-const EMPTY_GEOJSON_SRC = {
-  type: 'geojson',
-  data: EMPTY_GEOJSON
-};
-
 describe('Source', () => {
   let SourceWithContext: any;
   let addSourceMock: any;
   let removeSourceMock: any;
   let setDataMock: any;
-  let children: any[];
-  let childrenWithOneFeature: any[];
-  let feature: object;
+  const EMPTY_GEOJSON = {
+    'type': 'FeatureCollection',
+    'features': []
+  };
+
+  const EMPTY_GEOJSON_SRC = {
+    type: 'geojson',
+    data: EMPTY_GEOJSON
+  };
 
   beforeEach(() => {
     addSourceMock = jest.fn();
     removeSourceMock = jest.fn();
     setDataMock = jest.fn();
-    feature = { coordinates: [-123, 45] };
-    children = [{ props: {} }];
-    childrenWithOneFeature = [{ props: feature }];
 
     SourceWithContext = withContext({
       map: React.PropTypes.object
@@ -43,68 +36,20 @@ describe('Source', () => {
     }))(Source);
   });
 
-  it('Should render source with default options', () => {
+  it('Should render source with geoJsonSource', () => {
     mount(
       <SourceWithContext
         id="source-1"
         geoJsonSource={EMPTY_GEOJSON_SRC}
       /> as React.ReactElement<any>
     );
-    console.log('addSourceMock.mock.calls', addSourceMock.mock.calls);
+
     expect(addSourceMock.mock.calls[0]).toEqual(['source-1', {
       type: 'geojson',
       data: {
         type: 'FeatureCollection',
         features: []
       }
-    }]);
-  });
-
-  it('Should render source with default source', () => {
-    mount(
-      <SourceWithContext
-        children={children}
-      /> as React.ReactElement<any>
-    );
-
-    expect(addSourceMock.mock.calls[0]).toEqual(['source-2', {
-      type: 'geojson',
-      data: {
-        type: 'FeatureCollection',
-        features: []
-      }
-    }]);
-  });
-
-  it('Should set features based on children', () => {
-    const source = mount(
-      <SourceWithContext
-        children={childrenWithOneFeature}
-      /> as React.ReactElement<any>
-    );
-
-    expect(setDataMock.mock.calls[0]).toEqual([{
-      'type': 'FeatureCollection',
-      'features': [{
-        'geometry': { ...feature, 'type': 'Point' },
-        'properties': { id: 0 },
-        'type': 'Feature'
-      }]
-    }]);
-  });
-
-  it('Should set features to empty array when children disappear', () => {
-    const source = mount(
-      <SourceWithContext
-        children={childrenWithOneFeature}
-      /> as React.ReactElement<any>
-    );
-
-    source.setProps({ children: undefined });
-
-    expect(setDataMock.mock.calls[1]).toEqual([{
-      'type': 'FeatureCollection',
-      'features': []
     }]);
   });
 });

--- a/src/source.ts
+++ b/src/source.ts
@@ -47,11 +47,11 @@ export default class Source extends React.Component<Props, void> {
     const source = map.getSource(this.props.id) as GeoJSONSource;
 
     const { onSourceLoaded } = this.props;
-    if (onSourceLoaded) {
+    if (source && onSourceLoaded) {
       onSourceLoaded(source);
     }
     // Will fix datasource being empty
-    if (this.props.geoJsonSource && this.props.geoJsonSource.data) {
+    if (source && this.props.geoJsonSource && this.props.geoJsonSource.data) {
       source.setData(this.props.geoJsonSource.data as SourceOptionData);
     }
     map.off('load', this.onData);

--- a/src/source.ts
+++ b/src/source.ts
@@ -15,6 +15,7 @@ export interface Props {
   geoJsonSource?: GeoJSONSourceRaw;
   tileJsonSource?: TilesJson;
   onSourceAdded?: (source: GeoJSONSource | TilesJson) => any;
+  onSourceLoaded?: (source: GeoJSONSource | TilesJson) => any;
 }
 
 export default class Source extends React.Component<Props, void> {
@@ -32,11 +33,28 @@ export default class Source extends React.Component<Props, void> {
 
     if (!map.getSource(this.id) && (geoJsonSource || tileJsonSource)) {
       map.addSource(this.id, (geoJsonSource || tileJsonSource) as any);
+      map.on('load', this.onData);
 
       if (onSourceAdded) {
         onSourceAdded(map.getSource(this.id) as GeoJSONSource | TilesJson);
       }
     }
+  }
+
+  private onData = (event: any) => {
+    const { map } = this.context;
+
+    const source = map.getSource(this.props.id) as GeoJSONSource;
+
+    const { onSourceLoaded } = this.props;
+    if (onSourceLoaded) {
+      onSourceLoaded(source);
+    }
+    // Will fix datasource being empty
+    if (this.props.geoJsonSource && this.props.geoJsonSource.data) {
+      source.setData(this.props.geoJsonSource.data as SourceOptionData);
+    }
+    map.off('load', this.onData);
   }
 
   public componentWillUnmount() {


### PR DESCRIPTION
When adding the Source, data don't get loaded.

This fix this behavior by adding a one-time listener to [map:load](https://www.mapbox.com/mapbox-gl-js/api/#map.event:load) and setting source data.

This guarantees data being available after the load event has occurred. 

This PR also adds a `onSourceLoaded` which is similar to `onSourceAdded` and gets called after the map:load event.

I also updated the API.md docs