### PR TITLE
Deps update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 
 vendor/
 lib/

--- a/example/package.json
+++ b/example/package.json
@@ -10,18 +10,18 @@
     "build:watch": "NODE_ENV=dev webpack --watch"
   },
   "dependencies": {
-    "immutable": "^3.8.0",
-    "react": "^15.3.1",
-    "react-dom": "^15.3.1",
+    "immutable": "^3.8.1",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
-    "babel-core": "^6.18.2",
-    "babel-loader": "^6.2.7",
-    "babel-preset-philpl": "^0.4.0",
+    "babel-core": "^6.24.0",
+    "babel-loader": "^6.4.1",
+    "babel-preset-philpl": "^0.5.0",
     "json-loader": "^0.5.4",
-    "nodemon": "^1.10.2",
-    "webpack": "2.1.0-beta.27",
-    "webpack-dev-server": "^2.1.0-beta.11"
+    "nodemon": "^1.11.0",
+    "webpack": "2.3.3",
+    "webpack-dev-server": "^2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,31 +53,32 @@
   "homepage": "https://github.com/alex3165/react-mapbox-gl#readme",
   "dependencies": {
     "deep-equal": "^1.0.1",
-    "mapbox-gl": "^0.32.1",
     "reduce-object": "^0.1.3",
-    "supercluster": "^2.2.0"
+    "supercluster": "^2.3.0"
   },
   "peerDependencies": {
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "mapbox-gl": "^0.34.0",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
   },
   "devDependencies": {
-    "@types/core-js": "=0.9.36",
-    "@types/enzyme": "^2.7.4",
-    "@types/jest": "^18.1.1",
-    "@types/mapbox-gl": "^0.29.0",
-    "@types/node": "=7.0.5",
-    "@types/react": "^15.0.6",
-    "@types/recompose": "^0.20.3",
-    "enzyme": "^2.7.1",
-    "jest": "^17.0.1",
-    "react": "^15.4.0",
+    "@types/core-js": "^0.9.41",
+    "@types/enzyme": "^2.7.7",
+    "@types/jest": "^19.2.2",
+    "@types/mapbox-gl": "^0.30.0",
+    "@types/node": "^7.0.5",
+    "@types/react": "^15.0.21",
+    "@types/recompose": "^0.22.0",
+    "enzyme": "^2.8.0",
+    "jest": "^19.0.2",
+    "mapbox-gl": "^0.34.0",
+    "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.0",
-    "recompose": "^0.20.2",
-    "ts-jest": "^18.0.3",
-    "tslint": "^4.4.2",
-    "tslint-react": "^2.3.0",
-    "typescript": "^2.1.5"
+    "react-dom": "^15.4.2",
+    "recompose": "^0.22.0",
+    "ts-jest": "^19.0.6",
+    "tslint": "^5.0.0",
+    "tslint-react": "^2.5.0",
+    "typescript": "^2.2.2"
   }
 }

--- a/src/__tests__/map.test.tsx
+++ b/src/__tests__/map.test.tsx
@@ -5,7 +5,7 @@ const Map = jest.fn(() => ({
   on
 }));
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('mapbox-gl', () => ({
   Map
 }));
 

--- a/src/__tests__/overlays.test.ts
+++ b/src/__tests__/overlays.test.ts
@@ -1,4 +1,4 @@
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('mapbox-gl', () => ({
   default: {},
   LngLat: {}
 }));

--- a/src/cluster.tsx
+++ b/src/cluster.tsx
@@ -102,7 +102,7 @@ export default class Cluster extends React.Component<Props, State> {
 
   private childrenToFeatures = (children: Array<React.Component<MarkerProps, any>>) => (
     children.map((child) => this.feature(child && child.props.coordinates))
-  );
+  )
 
   public render() {
     const { children, ClusterMarkerFactory, clusterThreshold } = this.props;

--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as MapboxGL from 'mapbox-gl/dist/mapbox-gl';
+import * as MapboxGL from 'mapbox-gl';
 const isEqual = require('deep-equal'); //tslint:disable-line
 import diff from './util/diff';
 import { generateID } from './util/uid';

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -117,7 +117,7 @@ export default class ReactMapboxGl extends React.Component<Props & Events, State
 
   private calcCenter = (bounds: FitBounds): number[] => (
     [(bounds[0][0] + bounds[1][0]) / 2, (bounds[0][1] + bounds[1][1]) / 2]
-  );
+  )
 
   public componentDidMount() {
     const {

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -1,4 +1,4 @@
-import * as MapboxGl from 'mapbox-gl/dist/mapbox-gl';
+import * as MapboxGl from 'mapbox-gl';
 import * as React from 'react';
 const isEqual = require('deep-equal'); //tslint:disable-line
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -3,7 +3,7 @@ import {
   Map,
   GeoJSONSource,
   GeoJSONSourceRaw
-} from 'mapbox-gl/dist/mapbox-gl';
+} from 'mapbox-gl';
 import { SourceOptionData, TilesJson } from './util/types';
 
 export interface Context {

--- a/src/util/overlays.ts
+++ b/src/util/overlays.ts
@@ -1,5 +1,5 @@
-import { LngLat, Point } from 'mapbox-gl/dist/mapbox-gl';
-import * as MapboxGL from 'mapbox-gl/dist/mapbox-gl';
+import { LngLat, Point } from 'mapbox-gl';
+import * as MapboxGL from 'mapbox-gl';
 import { Props } from '../projected-layer';
 
 export type Anchor = (

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -20,7 +20,7 @@ export interface Feature {
     coordinates: GeoJSON.Position;
   };
   properties: any;
-};
+}
 
 export interface TilesJson {
   type: string;
@@ -29,4 +29,4 @@ export interface TilesJson {
   maxzoom: number;
   minzoom: number;
   tileSize?: number;
-};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,12 @@
     "outDir": "lib",
     "module": "commonjs",
     "target": "es5",
+    "lib":[
+      "es5",
+      "es2015",
+      "es2017",
+      "dom"
+    ],
     "sourceMap": true,
     "moduleResolution": "node",
     "rootDirs": ["src"],


### PR DESCRIPTION
This PR will:  

* Update *all dependencies* (including devDependencies, peerDependencies, example) to their latest versions (I used `npm outdated`).
* add .vscode to .gitignore (local workspace settings, for my mental sanity 😌  )
* Also fix a couple of tslint errors (extra semicolons etc) which were not found by the previous version of tslint.
* Use latest tsc which requires expliciting "libs" in the tsconfig.json
* Finally, fix import of `'mapbox-gl/dist/mapbox-gl'` to just `'mapbox-gl'`. This will works just the same way, because mapbox main module is 'mapbox-gl/dist/mapbox-gl' (see their package.json). **But this will allow people to define alias** in their webpack config files in their projects, e.g. for using mapbox-gl-dev or for compiling it from source. This makes the current library more agnostic on the developer choices on mapbox (e.g. using a debug environment, or compiling it from sources), while remaining compliant to its types thanks to `@types/mapbox-gl`.