### PR TITLE
Exposed renderWorldCopies Map option to properties.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,7 @@ import ReactMapboxGl from "react-mapbox-gl";
   - `top-right`
   - `bottom-left`
   - `bottom-right`
+- **renderWorldCopies** *(Default: `true`)*: `Boolean` If `true`, multiple copies of the world will be rendered, when zoomed out.
 - **onClick**: `(map: Object, event: Object) => void` : Triggered whenever user click on the map
 - **onStyleLoad**: `(map: Object, event: Object) => void` : Listener of Mapbox event : `map.on("style.load")`
 - **onMouseMove**: `(map: Object, event: Object) => void` : Listen the mouse moving on the map
@@ -212,7 +213,7 @@ import { ZoomControl } from "react-mapbox-gl";
 ### Properties
 - **onControlClick** : `(map: Object, zoomDiff: Number) => void` triggered when user click on minus or plus button
 - **style** : `Object` Style object merged with internal style into the container
-- **className**: `String` Custom style using className for the container 
+- **className**: `String` Custom style using className for the container
 - **zoomDiff** : `Number` The shift number passed to the callback `onControlClick`
 - **position** *(Default: `topRight`)*: `String` The control position, Possible values :
   - `topRight`

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -2,7 +2,7 @@ import * as MapboxGl from 'mapbox-gl';
 import * as React from 'react';
 const PropTypes = require('prop-types'); // tslint:disable-line
 
-const isEqual = require('deep-equal'); //tslint:disable-line		
+const isEqual = require('deep-equal'); //tslint:disable-line
 
 const events = {
   onResize: 'resize',
@@ -79,6 +79,7 @@ export interface Props {
   attributionControl?: boolean;
   logoPosition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
   children?: JSX.Element;
+  renderWorldCopies?: boolean;
 }
 
 export interface State {
@@ -105,7 +106,8 @@ export default class ReactMapboxGl extends React.Component<Props & Events, State
     pitch: 0,
     logoPosition: 'bottom-left',
     interactive: true,
-    dragRotate: true
+    dragRotate: true,
+    renderWorldCopies: true
   };
 
   public static childContextTypes = {
@@ -146,7 +148,8 @@ export default class ReactMapboxGl extends React.Component<Props & Events, State
       attributionControl,
       logoPosition,
       interactive,
-      dragRotate
+      dragRotate,
+      renderWorldCopies
     } = this.props;
 
     (MapboxGl as any).accessToken = accessToken;
@@ -167,7 +170,8 @@ export default class ReactMapboxGl extends React.Component<Props & Events, State
       scrollZoom,
       attributionControl,
       interactive,
-      dragRotate
+      dragRotate,
+      renderWorldCopies
     };
 
     const map = new MapboxGl.Map({

--- a/src/util/mapbox-type.d.ts
+++ b/src/util/mapbox-type.d.ts
@@ -215,6 +215,9 @@ declare namespace mapboxgl {
 
 		pitch?: number;
 
+		/** If true, multiple copies of the world will be rendered, when zoomed out. */
+		renderWorldCopies?: boolean;
+
 		/** If true, enable the "scroll to zoom" interaction */
 		scrollZoom?: boolean;
 


### PR DESCRIPTION
Added map property `renderWorldCopies` according to the Mapbox GL API (https://www.mapbox.com/mapbox-gl-js/api/).

My editor also killed some trailing whitespace automatically in the files I touched. Hope this is ok.

