### PR TITLE
Rotation control component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import ScaleControl from './scale-control';
 import Marker from './marker';
 import Source from './source';
 import Cluster from './cluster';
+import RotationControl from './rotation-control'
 
 injectCSS(window);
 
@@ -23,7 +24,8 @@ export {
   ScaleControl,
   Marker,
   Source,
-  Cluster
+  Cluster,
+  RotationControl
 };
 
 export default Map;

--- a/src/rotation-control.tsx
+++ b/src/rotation-control.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+const PropTypes = require('prop-types'); // tslint:disable-line
+import { Map } from 'mapbox-gl';
+
+const containerStyle: React.CSSProperties = {
+    position: 'absolute',
+    zIndex: 11,
+    display: 'flex',
+    flexDirection: 'column',
+    border: '1px solid rgba(0, 0, 0, 0.1)'
+} as React.CSSProperties;
+
+const positions = {
+    topRight: { top: 62, right: 10, bottom: 'auto', left: 'auto' },
+    topLeft: { top: 10, left: 10, bottom: 'auto', right: 'auto' },
+    bottomRight: { bottom: 10, right: 10, top: 'auto', left: 'auto' },
+    bottomLeft: { bottom: 10, left: 10, top: 'auto', right: 'auto' }
+};
+
+const buttonStyle = {
+    backgroundColor: '#f9f9f9',
+    opacity: 0.95,
+    transition: 'background-color 0.16s ease-out',
+    cursor: 'pointer',
+    border: 0,
+    height: 26,
+    width: 26,
+    outline: 0,
+    padding: 3
+};
+
+const buttonStyleHovered = {
+    backgroundColor: '#fff',
+    opacity: 1
+};
+
+const buttonStyleCompass = {
+    borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
+    borderTopLeftRadius: 2,
+    borderTopRightRadius: 2
+};
+
+const compassSpan = {
+    width: 20,
+    height: 20,
+    backgroundImage: 'url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%0A%09%3Cpolygon%20fill%3D%27%23333333%27%20points%3D%276%2C9%2010%2C1%2014%2C9%27%2F%3E%0A%09%3Cpolygon%20fill%3D%27%23CCCCCC%27%20points%3D%276%2C11%2010%2C19%2014%2C11%20%27%2F%3E%0A%3C%2Fsvg%3E")',
+    backgroundRepeat: 'no-repeat',
+    display: 'inline-block'
+}
+
+const [COMPASS] = [0];
+const POSITIONS = Object.keys(positions);
+
+export interface Props {
+    onControlClick: (map: Map, zoomDiff: number) => void;
+    position: 'topRight' | 'topLeft' | 'bottomRight' | 'bottomLeft';
+    style: React.CSSProperties;
+    className: string;
+}
+
+export interface State {
+    hover?: number;
+}
+
+export interface Context {
+    map: Map;
+}
+
+export default class RotationControl extends React.Component<Props, State> {
+
+    public context: Context;
+
+    public static defaultProps = {
+        position: POSITIONS[0]
+    };
+
+    public state = {
+        hover: undefined
+    };
+
+    public static contextTypes = {
+        map: PropTypes.object
+    };
+
+    public compassIcon: any;
+
+    private onMouseOut = () => {
+        if (!this.state.hover) {
+            this.setState({ hover: undefined });
+        }
+    }
+
+    private onMouseIn = () => {
+        if (COMPASS !== this.state.hover) {
+            this.setState({ hover: COMPASS });
+        }
+    }
+
+    private onClickCompass = () => {
+        this.context.map.resetNorth();
+    }
+
+    private onMapRotate = () => {
+        const rotate = `rotate(${this.context.map.transform.angle * (180 / Math.PI)}deg)`; // tslint:disable-line
+        this.compassIcon.style.transform = rotate;
+    }
+
+    public componentDidMount = () => {
+        this.context.map.on('rotate', this.onMapRotate);
+    }
+
+    public componentWillUnmount = () => {
+        this.context.map.off('rotate', this.onMapRotate);
+    }
+
+    public render() {
+        const { position, style, className } = this.props;
+        const { hover } = this.state;
+
+        return (
+            <div
+                className={className}
+                style={{ ...containerStyle, ...positions[position], ...style }}
+            >
+                <button
+                    style={{ ...buttonStyle, ...buttonStyleCompass, ...(hover === COMPASS ? buttonStyleHovered : {}) }}
+                    onMouseOver={this.onMouseIn}
+                    onMouseOut={this.onMouseOut}
+                    onClick={this.onClickCompass}
+                >
+                    <span ref={(icon) => this.compassIcon = icon}
+                        style={compassSpan}>
+                    </span>
+                </button>
+            </div>
+        );
+    }
+}

--- a/src/rotation-control.tsx
+++ b/src/rotation-control.tsx
@@ -3,136 +3,136 @@ const PropTypes = require('prop-types'); // tslint:disable-line
 import { Map } from 'mapbox-gl';
 
 const containerStyle: React.CSSProperties = {
-    position: 'absolute',
-    zIndex: 11,
-    display: 'flex',
-    flexDirection: 'column',
-    border: '1px solid rgba(0, 0, 0, 0.1)'
+  position: 'absolute',
+  zIndex: 11,
+  display: 'flex',
+  flexDirection: 'column',
+  boxShadow: '0px 1px 4px rgba(0, 0, 0, .3)',
+  border: '1px solid rgba(0, 0, 0, 0.1)'
 } as React.CSSProperties;
 
 const positions = {
-    topRight: { top: 62, right: 10, bottom: 'auto', left: 'auto' },
-    topLeft: { top: 10, left: 10, bottom: 'auto', right: 'auto' },
-    bottomRight: { bottom: 10, right: 10, top: 'auto', left: 'auto' },
-    bottomLeft: { bottom: 10, left: 10, top: 'auto', right: 'auto' }
+  topRight: { top: 62, right: 10, bottom: 'auto', left: 'auto' },
+  topLeft: { top: 62, left: 10, bottom: 'auto', right: 'auto' },
+  bottomRight: { bottom: 63, right: 10, top: 'auto', left: 'auto' },
+  bottomLeft: { bottom: 63, left: 10, top: 'auto', right: 'auto' }
 };
 
 const buttonStyle = {
-    backgroundColor: '#f9f9f9',
-    opacity: 0.95,
-    transition: 'background-color 0.16s ease-out',
-    cursor: 'pointer',
-    border: 0,
-    height: 26,
-    width: 26,
-    outline: 0,
-    padding: 3
+  backgroundColor: '#f9f9f9',
+  opacity: 0.95,
+  transition: 'background-color 0.16s ease-out',
+  cursor: 'pointer',
+  border: 0,
+  height: 26,
+  width: 26,
+  outline: 0,
+  padding: 3
 };
 
 const buttonStyleHovered = {
-    backgroundColor: '#fff',
-    opacity: 1
+  backgroundColor: '#fff',
+  opacity: 1
 };
 
 const buttonStyleCompass = {
-    borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
-    borderTopLeftRadius: 2,
-    borderTopRightRadius: 2
+  borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
+  borderTopLeftRadius: 2,
+  borderTopRightRadius: 2
 };
 
 const compassSpan = {
-    width: 20,
-    height: 20,
-    backgroundImage: 'url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%0A%09%3Cpolygon%20fill%3D%27%23333333%27%20points%3D%276%2C9%2010%2C1%2014%2C9%27%2F%3E%0A%09%3Cpolygon%20fill%3D%27%23CCCCCC%27%20points%3D%276%2C11%2010%2C19%2014%2C11%20%27%2F%3E%0A%3C%2Fsvg%3E")',
-    backgroundRepeat: 'no-repeat',
-    display: 'inline-block'
+  width: 20,
+  height: 20,
+  backgroundImage: 'url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%0A%09%3Cpolygon%20fill%3D%27%23333333%27%20points%3D%276%2C9%2010%2C1%2014%2C9%27%2F%3E%0A%09%3Cpolygon%20fill%3D%27%23CCCCCC%27%20points%3D%276%2C11%2010%2C19%2014%2C11%20%27%2F%3E%0A%3C%2Fsvg%3E")',
+  backgroundRepeat: 'no-repeat',
+  display: 'inline-block'
 }
 
 const [COMPASS] = [0];
 const POSITIONS = Object.keys(positions);
 
 export interface Props {
-    onControlClick: (map: Map, zoomDiff: number) => void;
-    position: 'topRight' | 'topLeft' | 'bottomRight' | 'bottomLeft';
-    style: React.CSSProperties;
-    className: string;
+  position: 'topRight' | 'topLeft' | 'bottomRight' | 'bottomLeft';
+  style: React.CSSProperties;
+  className: string;
 }
 
 export interface State {
-    hover?: number;
+  hover?: number;
 }
 
 export interface Context {
-    map: Map;
+  map: Map;
 }
 
 export default class RotationControl extends React.Component<Props, State> {
 
-    public context: Context;
+  public context: Context;
 
-    public static defaultProps = {
-        position: POSITIONS[0]
-    };
+  public static defaultProps = {
+    position: POSITIONS[0]
+  };
 
-    public state = {
-        hover: undefined
-    };
+  public state = {
+    hover: undefined
+  };
 
-    public static contextTypes = {
-        map: PropTypes.object
-    };
+  public static contextTypes = {
+    map: PropTypes.object
+  };
 
-    public compassIcon: any;
+  public compassIcon: any;
 
-    private onMouseOut = () => {
-        if (!this.state.hover) {
-            this.setState({ hover: undefined });
-        }
+  private onMouseOut = () => {
+    if (!this.state.hover) {
+      this.setState({ hover: undefined });
     }
+  }
 
-    private onMouseIn = () => {
-        if (COMPASS !== this.state.hover) {
-            this.setState({ hover: COMPASS });
-        }
+  private onMouseIn = () => {
+    if (COMPASS !== this.state.hover) {
+      this.setState({ hover: COMPASS });
     }
+  }
 
-    private onClickCompass = () => {
-        this.context.map.resetNorth();
-    }
+  private onClickCompass = () => {
+    this.context.map.resetNorth();
+  }
 
-    private onMapRotate = () => {
-        const rotate = `rotate(${this.context.map.transform.angle * (180 / Math.PI)}deg)`; // tslint:disable-line
-        this.compassIcon.style.transform = rotate;
-    }
+  private onMapRotate = () => {
+    const rotate = `rotate(${this.context.map.transform.angle * (180 / Math.PI)}deg)`; // tslint:disable-line
+    this.compassIcon.style.transform = rotate;
+  }
 
-    public componentDidMount = () => {
-        this.context.map.on('rotate', this.onMapRotate);
-    }
+  public componentDidMount = () => {
+    this.context.map.on('rotate', this.onMapRotate);
+  }
 
-    public componentWillUnmount = () => {
-        this.context.map.off('rotate', this.onMapRotate);
-    }
+  public componentWillUnmount = () => {
+    this.context.map.off('rotate', this.onMapRotate);
+  }
 
-    public render() {
-        const { position, style, className } = this.props;
-        const { hover } = this.state;
+  public render() {
+    const { position, style, className } = this.props;
+    const { hover } = this.state;
 
-        return (
-            <div
-                className={className}
-                style={{ ...containerStyle, ...positions[position], ...style }}
-            >
-                <button
-                    style={{ ...buttonStyle, ...buttonStyleCompass, ...(hover === COMPASS ? buttonStyleHovered : {}) }}
-                    onMouseOver={this.onMouseIn}
-                    onMouseOut={this.onMouseOut}
-                    onClick={this.onClickCompass}
-                >
-                    <span ref={(icon) => this.compassIcon = icon}
-                        style={compassSpan}>
-                    </span>
-                </button>
-            </div>
-        );
-    }
+    return (
+      <div
+        className={className}
+        style={{ ...containerStyle, ...positions[position], ...style }}
+      >
+        <button
+          style={{ ...buttonStyle, ...buttonStyleCompass, ...(hover === COMPASS ? buttonStyleHovered : {}) }}
+          onMouseOver={this.onMouseIn}
+          onMouseOut={this.onMouseOut}
+          onClick={this.onClickCompass}
+        >
+          <span ref={(icon) => this.compassIcon = icon}
+            style={compassSpan}>
+          </span>
+        </button>
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
I added the Rotation Control Widget which was requested on #204, but before it's merged, I want to check if making a `NavigationControl` wrapper would be the best solution when the user wants to display the `ZoomControl` component and the `RotationControl` at the same time.

Having a `NavigationControl` component would make the `hover` property in the state easier to manage between the navigation components and also make the styling easier, as right now the borders of the component this PR collide with the `ZoomControl` ones.

Shortcomings of this PR:
- No tests yet (will wait until the issue with the wrapper is defined).
- Displaying both `ZoomControl` and `RotationControl` doesn't look great aesthetically.
- Styling needs some polishing.
- I used the `transform` property of the map object though it's not exposed on the mapbox-gl typings.

Doubts regarding guidelines:
- I used the compass icon that mapbox-gl itself uses on it's css, I don't know if this is desired.

If any maintainer wants to discuss approaches I'd be happy to help.