### PR TITLE
Include new and removed keys in diff results

### DIFF
--- a/src/__tests__/diff.test.ts
+++ b/src/__tests__/diff.test.ts
@@ -1,0 +1,81 @@
+import diff from '../util/diff';
+
+describe('diff', () => {
+  it('Should return no differences', () => {
+    const obj1: any = {
+      key1: 0,
+    };
+
+    const obj2: any = {
+      key1: 0,
+    };
+
+    const res = diff(obj1, obj2);
+
+    expect(res).toEqual(
+      {}
+    );
+  });
+
+  it('Should return one difference', () => {
+    const obj1: any = {
+      key1: 0,
+    };
+
+    const obj2: any = {
+      key1: 1,
+    };
+
+    const res = diff(obj1, obj2);
+
+    expect(res).toEqual(
+      {key1: 1}
+    );
+  });
+
+  it('Should return 1 removed key', () => {
+    const obj1: any = {
+      key1: 0, 
+    };
+
+    const obj2: any = {
+    };
+
+    const res = diff(obj1, obj2);
+
+    expect(res).toEqual(
+      {key1: undefined}
+    );
+  });
+
+  it('Should return 1 added key', () => {
+    const obj1: any = {
+    };
+
+    const obj2: any = {
+      key1: 0,
+    };
+
+    const res = diff(obj1, obj2);
+
+    expect(res).toEqual(
+      {key1: 0}
+    );
+  });
+
+  it('Should return 1 removed and 1 added key', () => {
+    const obj1: any = {
+      key1: 0,
+    };
+
+    const obj2: any = {
+      key2: 0,
+    };
+
+    const res = diff(obj1, obj2);
+
+    expect(res).toEqual(
+      {key1: undefined, key2: 0}
+    );
+  });
+});

--- a/src/util/diff.ts
+++ b/src/util/diff.ts
@@ -1,17 +1,11 @@
-const reduce = require('reduce-object'); // tslint:disable-line
-
-const find = (obj: any, predicate: (...args: any[]) => boolean) => (
-  Object.keys(obj).filter((key) => predicate(obj[key], key))[0]
-);
-
-const diff = (obj1: any, obj2: any) => (
-  reduce(obj2, (res: any, value: any, key: string) => {
-    const toMutate = res;
-    if (find(obj1, (v, k) => key === k && value !== v)) {
-      toMutate[key] = value;
+const diff = (obj1: any, obj2: any) => {
+  const toMutate = {};
+  Array.from(new Set([...Object.keys(obj1), ...Object.keys(obj2)])).map((key) => {
+    if (obj1[key] !== obj2[key]) {
+      toMutate[key] = obj2[key];
     }
-    return toMutate;
-  }, {})
-);
+  });
+  return toMutate;
+};
 
 export default diff;


### PR DESCRIPTION
The current diff only returns keys that are in both objects, so anything added or removed from paint/layout doesn't get updated on the map.