### PR TITLE
GeoJSONLayer style update fails

### DIFF
--- a/example/src/style-update.js
+++ b/example/src/style-update.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import ReactMap, { Layer, Source, Feature } from "react-mapbox-gl";
+import ReactMap, { Layer, Source, Feature, GeoJSONLayer } from "react-mapbox-gl";
 
 const accessToken = "pk.eyJ1IjoiYWxleDMxNjUiLCJhIjoiY2l4b3V0Z3RpMDAxczJ4cWk2YnEzNTVzYSJ9.MFPmOyHy8DM5_CVaqPYhOg";
 const streetsStyle = "mapbox://styles/mapbox/streets-v9";
@@ -74,7 +74,10 @@ const POSITION_CIRCLE_PAINT = {
     'circle-color': '#0066EE',
     'circle-stroke-color': '#FFFFFF'
 };
-const DEFAULT_USER_POSITION = [-0.2416815, 51.5285582];
+const DEFAULT_USER_POSITION = [ -77.01239, 38.91275 ]
+
+
+import geojson from "./geojson.json";
 
 class StyleUpdate extends Component {
   state = {
@@ -113,14 +116,23 @@ class StyleUpdate extends Component {
           center={this.state.userPosition}
         >
           <Source id="example_id" geoJsonSource={GEOJSON_SOURCE_OPTIONS} />
-          <Layer type="circle" id="example_id_marker" paint={POSITION_CIRCLE_PAINT} sourceId={'example_id'} /> 
+          <Layer type="circle" id="example_id_marker" paint={POSITION_CIRCLE_PAINT} sourceId={'example_id'} />
           <Layer type="circle" id="position-marker" paint={POSITION_CIRCLE_PAINT}>
             <Feature coordinates={this.state.userPosition} />
           </Layer>
+          <GeoJSONLayer
+            data={geojson}
+            circleLayout={{ visibility: "visible" }}
+            symbolLayout={{
+              "text-field": "{place}",
+              "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+              "text-offset": [0, 0.6],
+              "text-anchor": "top"
+            }}/>
         </ReactMap>
-        
+
         <button style={styles.button} onClick={this.nextStyle}>Switch Style</button>
-        
+
         <div style={styles.indicator}>
           { `Using style: "${this.getStyleKey()}"` }
         </div>


### PR DESCRIPTION
Initially in my code, I was getting this (doesn't happen in this example PR).
```
geojson-layer.js:77 Uncaught TypeError: Cannot read property 'setData' of undefined
    at GeoJSONLayer.componentWillReceiveProps (geojson-layer.js:77)
```

Fails right here:
```
    if (props.data !== data) {
      (map.getSource(id) as MapboxGL.GeoJSONSource).setData(props.data);
    }
```
`map.getSource(id)` is returning `undefined`.

I tried cloning the library and updating the example to show this:
https://github.com/alex3165/react-mapbox-gl/pull/260

In the example, there are no errors in the console, but the layer is not re-rendered. If you check out that branch and go to the "Style update" tab, you can see what I'm talking about.

If you switch the style the GEOJSONLayer is NOT re-rendered.

This is just to show that it doesn't work. I am not sure quite yet how to fix it or if I'll have time to tackle it. I hope it's easy for the core devs to fix :)