### PR TITLE
removing empty accessToken=

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ const Map = ReactMapboxGl({
 
 <Map
   style="mapbox://styles/mapbox/streets-v9"
-  accessToken=
   containerStyle={{
     height: "100vh",
     width: "100vw"


### PR DESCRIPTION
doesn't seem needed now that it is set on the Factory. Also invalid JSX.