### PR TITLE
WIP: feat(cluster): add getLeaves argument to factory

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -406,7 +406,9 @@ clusterMarker = (coordinates) => (
 ```
 
 ### Properties
-- **ClusterMarkerFactory** *(required)*: `(coordinates: number[], pointCount: number) => Marker` A function called for every cluster, the function must return a Marker component
+- **ClusterMarkerFactory** *(required)*: `(coordinates: number[], pointCount: number, getLeaves: (limit?: number, offset?: number) => Array<React.ReactElement<any>>) => Marker` A function called for every cluster, the function must return a Marker component
+  - `getLeaves()` return `Cluster` children of a cluster, with pagination support: limit is the number of points to return (set to Infinity for all points, default to 10), and offset is the amount of points to skip (for pagination).
+
 - **radius**: *Default: 60*:`Number` Cluster radius, in pixels.
 - **minZoom**: *Default: 0*:`Number` Minimum zoom level at which clusters are generated.
 - **maxZoom**: *Default: 16*:`Number` Maximum zoom level at which clusters are generated.

--- a/src/__tests__/cluster.test.tsx
+++ b/src/__tests__/cluster.test.tsx
@@ -82,9 +82,12 @@ describe('cluster', () => {
       />
     );
 
-    expect(clusterMarkerFactory.mock.calls[0]).toEqual([
-      [-9.11968680123703, 40.047086577057655],
-      2
-    ]);
+    const call = clusterMarkerFactory.mock.calls[0];
+    // coordinates
+    expect(call[0]).toEqual([-9.11968680123703, 40.047086577057655]);
+    // pointCount
+    expect(call[1]).toEqual(2);
+    // getLeaves
+    expect(call[2]().length).toEqual(2);
   });
 });

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -6,8 +6,7 @@ const isEqual = require('deep-equal'); //tslint:disable-line
 import diff from './util/diff';
 import * as GeoJSON from 'geojson';
 import { generateID } from './util/uid';
-import { Sources } from './util/types';
-import { Feature } from './util/types';
+import { Sources, Feature } from './util/types';
 import { Props as FeatureProps } from './feature';
 
 export type Paint = any;

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import ProjectedLayer from './projected-layer';
-import { anchors, Anchor } from './util/overlays';
+import { anchors, Anchor, PointDef } from './util/overlays';
 import * as GeoJSON from 'geojson';
 import { getClassName } from './util/classname';
-import { PointDef } from './util/overlays';
 
 export interface Props {
   coordinates: GeoJSON.Position;

--- a/src/projected-layer.tsx
+++ b/src/projected-layer.tsx
@@ -2,10 +2,15 @@ import * as React from 'react';
 const PropTypes = require('prop-types'); // tslint:disable-line
 
 import { Map } from 'mapbox-gl';
-import { Anchor, PointDef, OverlayProps } from './util/overlays';
+import {
+  Anchor,
+  PointDef,
+  OverlayProps,
+  overlayState,
+  overlayTransform,
+  anchors
+} from './util/overlays';
 import * as GeoJSON from 'geojson';
-
-import { overlayState, overlayTransform, anchors } from './util/overlays';
 
 const defaultStyle = {
   zIndex: 3

--- a/src/util/overlays.ts
+++ b/src/util/overlays.ts
@@ -1,5 +1,4 @@
-import { LngLat, Point } from 'mapbox-gl';
-import * as MapboxGL from 'mapbox-gl';
+import { LngLat, Point, Map } from 'mapbox-gl';
 import { Props } from '../projected-layer';
 
 export type Anchor =
@@ -54,11 +53,11 @@ const defaultElement = { offsetWidth: 0, offsetHeight: 0 };
 const isPointLike = (input: Point | any[]): boolean =>
   input instanceof Point || Array.isArray(input);
 
-const projectCoordinates = (map: MapboxGL.Map, coordinates: number[]) =>
+const projectCoordinates = (map: Map, coordinates: number[]) =>
   map.project(LngLat.convert(coordinates));
 
 const calculateAnchor = (
-  map: MapboxGL.Map,
+  map: Map,
   offsets: any,
   position: PointDef,
   { offsetHeight, offsetWidth } = defaultElement
@@ -125,7 +124,7 @@ const normalizedOffsets = (offset: any): any => {
 
 export const overlayState = (
   props: Props,
-  map: MapboxGL.Map,
+  map: Map,
   container: HTMLElement
 ) => {
   const position = projectCoordinates(map, props.coordinates);


### PR DESCRIPTION
Feature asked in #208 
It's working, but something must be changed in the cluster API to transmit original feature properly.
Until today, converting `Marker` props to feature was good enough, since we didn't need to access properties of the original feature.
Right now the only thing `getLeaves` can return is `Marker` component, which doesn't contain original feature data.
So in order to show what's inside the `Marker` we have to do this (two children here to skip the div element): `{leaf.props.children.props.children}`).

We could store the feature inside `Marker` and get it like that: `{leaf.props['data-feature']}`.
But it doesn't feel right...