### PR TITLE
fix(cluster): actually use the arguemnts provided to getLeaves

### DIFF
--- a/src/cluster.tsx
+++ b/src/cluster.tsx
@@ -147,10 +147,10 @@ export default class Cluster extends React.Component<Props, State> {
       return feature;
     });
 
-  private getLeaves = (feature: Feature) => {
+  private getLeaves = (feature: Feature, limit?: number, offset?: number) => {
     const { superC } = this.state;
     return superC
-      .getLeaves(feature.properties.cluster_id)
+      .getLeaves(feature.properties.cluster_id, limit, offset)
       .map((leave: Feature) => this.featureClusterMap.get(leave));
   };
 


### PR DESCRIPTION
Pass through the arguments to supercluster so the pagination actually works [as documented](https://github.com/alex3165/react-mapbox-gl/blob/ac71beba10b644fcfb8b6345ab13008e956dd554/docs/API.md#properties-9)