### PR TITLE
Move CSS injection into Map factory; FIXES #397

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,7 @@ const Map = ReactMapboxGl({
 - **failIfMajorPerformanceCaveat** *(Default: `false`)*: `boolean` If  `true` , map creation will fail if the performance of Mapbox GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
 - **classes**: `string[]` Mapbox style class names with which to initialize the map. Keep in mind that these classes are used for controlling a style layer's paint properties, so are not reflected in an HTML element's  class attribute. To learn more about Mapbox style classes, read about Layers in the style specification.
 - **bearingSnap** *(Default: `7`)*: `number` The threshold, measured in degrees, that determines when the map's bearing (rotation) will snap to north. For example, with a  bearingSnap of 7, if the user rotates the map within 7 degrees of north, the map will automatically snap to exact north.
+- **injectCss** *(Default: `true`)*: `boolean` If `false`, the factory will no try to inject the default CSS for the map into the `<head>` element.
 
 
 ### Component Properties

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 // Add a style tag to the document's head for the map's styling
-import injectCSS from './util/inject-css';
 import Map from './map';
 import BaseLayer, { LayerCommonProps, Props as LayerProps } from './layer';
 import layerMouseTouchEvents, { EnhancedLayerProps } from './layer-events-hoc';
@@ -14,8 +13,6 @@ import Cluster from './cluster';
 import RotationControl from './rotation-control';
 import { Context } from './util/types';
 import * as PropTypes from 'prop-types';
-
-injectCSS(window);
 
 // Hack to get around import issue from external lib, see: https://github.com/Microsoft/TypeScript/issues/9944
 // TODO: Remove this hack once the above issue is fixed

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -1,6 +1,7 @@
 import * as MapboxGl from 'mapbox-gl';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import injectCSS from './util/inject-css';
 const isEqual = require('deep-equal'); //tslint:disable-line
 
 const events = {
@@ -168,6 +169,7 @@ export interface FactoryParameters {
   failIfMajorPerformanceCaveat?: boolean;
   classes?: string[];
   bearingSnap?: number;
+  injectCss?: boolean;
 }
 
 // Satisfy typescript pitfall with defaultProps
@@ -209,9 +211,14 @@ const ReactMapboxFactory = ({
   refreshExpiredTiles = true,
   failIfMajorPerformanceCaveat = false,
   classes,
-  bearingSnap = 7
-}: FactoryParameters): any =>
-  class ReactMapboxGl extends React.Component<Props & Events, State> {
+  bearingSnap = 7,
+  injectCss = true
+}: FactoryParameters): any => {
+  if (injectCss) {
+    injectCSS(window);
+  }
+
+  return class ReactMapboxGl extends React.Component<Props & Events, State> {
     public static defaultProps = {
       onStyleLoad: (...args: any[]) => args,
       center: defaultCenter,
@@ -429,5 +436,6 @@ const ReactMapboxFactory = ({
       );
     }
   };
+}
 
 export default ReactMapboxFactory;


### PR DESCRIPTION
CSS injection can now be deactivated by passing `injectCss: false` to the Map factory.

To prevent a breaking change, the legacy way of injecting CSS is still on by default and has to be deactivated via `window.MAPBOX_SKIP_CSS_INJECTION = true` before importing the package.

For the next release with breaking changes, the block in `index.ts` can simply be removed.