### PR TITLE
Scale control is twice as width as it should be

### DIFF
--- a/src/scale-control.tsx
+++ b/src/scale-control.tsx
@@ -62,7 +62,7 @@ const MILE_IN_KILOMETERS = 1.60934;
 const MILE_IN_FEET = 5280;
 const KILOMETER_IN_METERS = 1000;
 
-const MIN_WIDTH_SCALE = 40;
+const MIN_WIDTH_SCALE = 60;
 
 export type Measurement = 'km' | 'mi';
 
@@ -137,7 +137,7 @@ export default class ScaleControl extends React.Component<Props, State> {
     }, 0);
 
     // tslint:disable-next-line:no-any
-    const scaleWidth = chosenScale / totalWidth * (map as any)._canvas.width;
+    const scaleWidth = chosenScale / totalWidth * clientWidth;
 
     this.setState({
       chosenScale,


### PR DESCRIPTION
_canvas.width seems to be twice as large as the actual clientWidth. In result, the scale control was being rendered twice as large as it should be; you can easily verify this using the example project and comparing the results to google map distance measurement, for example.

My fix uses clientWidth instead of canvas width, making the control the correct width. This leaves the control quite small, so I also adjusted the MIN_WIDTH_SCALE.