### PR TITLE
Allow scroll events on HTML Layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
   "peerDependencies": {
     "mapbox-gl": "0.44.0",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1 || ^16.0.0",
-    "react-dom": "^15.6.1 || ^16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "@types/core-js": "0.9.43",

--- a/src/__tests__/cluster.test.tsx
+++ b/src/__tests__/cluster.test.tsx
@@ -67,6 +67,7 @@ describe('cluster', () => {
           on: jest.fn(),
           getZoom: jest.fn(() => 2),
           getCanvas: jest.fn(() => ({ width: 1020, height: 800 })),
+          getCanvasContainer: jest.fn(() => null),
           unproject: jest.fn(() => mockProjections[unprojectCalls++]),
           project: jest.fn()
         }

--- a/src/projected-layer.tsx
+++ b/src/projected-layer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createPortal } from 'react-dom';
 import * as PropTypes from 'prop-types';
 import { Map, Point } from 'mapbox-gl';
 import { OverlayParams, overlayState, overlayTransform } from './util/overlays';
@@ -93,6 +94,16 @@ export default class ProjectedLayer extends React.Component<
     map.off('move', this.handleMapMove);
   }
 
+  public renderIntoContainer(child: React.ReactNode): React.ReactNode {
+    if (this.props.type === 'marker') {
+      const container = this.context.map.getCanvasContainer();
+
+      return container ? createPortal(child, container) : child;
+    }
+
+    return child;
+  }
+
   public render() {
     const {
       style,
@@ -115,7 +126,7 @@ export default class ProjectedLayer extends React.Component<
     };
     const anchorClassname =
       anchor && type === 'popup' ? `mapboxgl-popup-anchor-${anchor}` : '';
-    return (
+    return this.renderIntoContainer(
       <div
         className={`${className} ${anchorClassname}`}
         onClick={onClick}


### PR DESCRIPTION
Fixes #217 
Could switch to `ReactDOM.createPortal` at some point if dropping support for React 15