### PR TITLE
Checks to ensure that the source has been added to the map

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -116,7 +116,8 @@ export default class Source extends React.Component<Props> {
     if (
       geoJsonSource &&
       props.geoJsonSource &&
-      props.geoJsonSource.data !== geoJsonSource.data
+      props.geoJsonSource.data !== geoJsonSource.data &&
+      map.getSource(this.id)
     ) {
       const source = map.getSource(this.id) as GeoJSONSource;
       source.setData(props.geoJsonSource.data as SourceOptionData);


### PR DESCRIPTION
Addresses: https://github.com/alex3165/react-mapbox-gl/issues/501

This ensures that the map has the source before attempting to set the data. This is important because `componentWillReceiveProps` is fired before the style change handler. Since all the sources are removed after the style change, this throws an error.