### PR TITLE
Set the ZoomControl div to tabIndex -1 to remove from keyboard control flow

### DIFF
--- a/src/zoom-control.tsx
+++ b/src/zoom-control.tsx
@@ -132,6 +132,7 @@ export default class ZoomControl extends React.Component<Props, State> {
       <div
         className={className}
         style={{ ...containerStyle, ...positions[position!], ...style }}
+        tabIndex={-1}
       >
         <button
           type="button"


### PR DESCRIPTION
As Mapbox-gl provides keyboard interactions when the map canvas is focused having the zoom controls also keyboard accessible makes little sense. They are already annoying to get to as a user has to tab past the Mapbox logo, terms and conditions for Mapbox and OpenStreetMap *and* an Improve this map link just to trigger them.

Future improvements could be made by providing a pop-up or toast for keyboard users outlining the controls they have access to.