### PR TITLE
rename style to mapStyle, containerStyle to style

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ const Map = ReactMapboxGl({
 });
 
 <Map
-  style="mapbox://styles/mapbox/streets-v9"
-  containerStyle={{
+  mapStyle="mapbox://styles/mapbox/streets-v9"
+  style={{
     height: "100vh",
     width: "100vw"
   }}>

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,7 +13,7 @@ const Map = ReactMapboxGl({
   accessToken: "pk.eyJ1IjoiZmFicmljOCIsImEiOiJjaWc5aTV1ZzUwMDJwdzJrb2w0dXRmc2d0In0.p6GGlfyV-WksaDV_KdN27A"
 });
 
-<Map style="mapbox://styles/mapbox/streets-v8"/>
+<Map mapStyle="mapbox://styles/mapbox/streets-v8"/>
 ```
 
 ### Factory parameters
@@ -46,7 +46,7 @@ const Map = ReactMapboxGl({
 
 
 ### Component Properties
-- **style** *(required)* : `string | object`  Mapbox map style, if changed, the style will be updated using `setStyle`.
+- **mapStyle** *(required)* : `string | object`  Mapbox map style, if changed, the style will be updated using `setStyle`.
 - **center** *(Default: `[ -0.2416815, 51.5285582 ]`)*: `[number, number]` Center the map at the position at initialisation
   - Must be in longitude, latitude coordinate order (as opposed to latitude, longitude) to match GeoJSON (source: https://www.mapbox.com/mapbox-gl-js/api/#lnglat). 
   - Re-center the map if the value change regarding the prev value or the actual center position [flyTo](https://www.mapbox.com/mapbox-gl-js/api/#Map.flyTo)
@@ -58,7 +58,7 @@ const Map = ReactMapboxGl({
 - **bearing**: `[number]` Bearing (rotation) of the map at initialisation measured in degrees counter-clockwise from north.
   - Check the previous value and the new one, if the value changed update the bearing value [flyTo](https://www.mapbox.com/mapbox-gl-js/api/#Map.flyTo)
 - **pitch**: `[number]` Pitch (tilt) of the map at initialisation, range : `0 - 60`
-- **containerStyle** : `object` The style of the container of the map passed as an object
+- **style** : `object` The style of the container of the map passed as an object
 - **className** : `string` ClassName passed down to the container div
 - **movingMethod** *(Default: `flyTo`)*: `string` define the method used when changing the center or zoom position. Possible value :
   - `jumpTo`

--- a/example/src/demos/allShapes.tsx
+++ b/example/src/demos/allShapes.tsx
@@ -27,7 +27,7 @@ const mappedRoute = route.points.map(point => [point.lat, point.lng]);
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -115,8 +115,8 @@ class AllShapes extends React.Component<Props, State> {
   public render() {
     return (
       <Map
-        style={mapData}
-        containerStyle={mapStyle}
+        mapStyle={mapData}
+        style={mapContainerStyle}
         // tslint:disable-next-line:jsx-no-lambda
         onStyleLoad={this.onStyleLoad}
         center={this.state.center}

--- a/example/src/demos/geojsonLayer.tsx
+++ b/example/src/demos/geojsonLayer.tsx
@@ -9,7 +9,7 @@ const geojson = require('./geojson.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -50,9 +50,9 @@ class GeoJsonLayer extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <GeoJSONLayer

--- a/example/src/demos/heatmap.tsx
+++ b/example/src/demos/heatmap.tsx
@@ -8,7 +8,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -66,9 +66,9 @@ export default class Heatmap extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <Layer type="heatmap" paint={layerPaint as any}>

--- a/example/src/demos/htmlCluster.tsx
+++ b/example/src/demos/htmlCluster.tsx
@@ -9,7 +9,7 @@ const falls = require('./falls.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -118,11 +118,11 @@ class HtmlCluster extends React.Component<Props, State> {
 
     return (
       <Map
-        style={outdoor}
+        mapStyle={outdoor}
         zoom={this.zoom}
         onStyleLoad={this.onStyleLoad}
         onMove={this.onMove}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
       >
         <Cluster ClusterMarkerFactory={this.clusterMarker}>
           {falls.features.map((feature: any, key: number) => (

--- a/example/src/demos/htmlFeatures.tsx
+++ b/example/src/demos/htmlFeatures.tsx
@@ -26,7 +26,7 @@ const Mark = styled.div`
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   width: '100%',
   height: '100%'
 };
@@ -112,8 +112,8 @@ class HtmlFeatures extends React.Component<Props, State> {
           options={options}
         />
         <Map
-          style={styles.light}
-          containerStyle={mapStyle}
+          mapStyle={styles.light}
+          style={mapContainerStyle}
           center={center}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/londonCycle.tsx
+++ b/example/src/demos/londonCycle.tsx
@@ -14,7 +14,7 @@ const Mapbox = ReactMapboxGl({
   accessToken: token
 });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -99,14 +99,14 @@ export default class LondonCycle extends React.Component<Props, State> {
 
     return (
       <Mapbox
-        style={styles.londonCycle}
+        mapStyle={styles.londonCycle}
         onStyleLoad={this.onStyleLoad}
         fitBounds={fitBounds}
         maxBounds={maxBounds}
         center={center}
         zoom={zoom}
         onDrag={this.onDrag}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         flyToOptions={flyToOptions}
       >
         <Layer type="symbol" id="marker" layout={layoutLayer} images={images}>

--- a/example/src/demos/raws/allShapes.raw
+++ b/example/src/demos/raws/allShapes.raw
@@ -27,7 +27,7 @@ const mappedRoute = route.points.map(point => [point.lat, point.lng]);
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -115,8 +115,8 @@ class AllShapes extends React.Component<Props, State> {
   public render() {
     return (
       <Map
-        style={mapData}
-        containerStyle={mapStyle}
+        mapStyle={mapData}
+        style={mapContainerStyle}
         // tslint:disable-next-line:jsx-no-lambda
         onStyleLoad={this.onStyleLoad}
         center={this.state.center}

--- a/example/src/demos/raws/geojsonLayer.raw
+++ b/example/src/demos/raws/geojsonLayer.raw
@@ -9,7 +9,7 @@ const geojson = require('./geojson.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -50,9 +50,9 @@ class GeoJsonLayer extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <GeoJSONLayer

--- a/example/src/demos/raws/heatmap.raw
+++ b/example/src/demos/raws/heatmap.raw
@@ -8,7 +8,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -66,9 +66,9 @@ export default class Heatmap extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <Layer type="heatmap" paint={layerPaint as any}>

--- a/example/src/demos/raws/htmlCluster.raw
+++ b/example/src/demos/raws/htmlCluster.raw
@@ -9,7 +9,7 @@ const falls = require('./falls.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -118,11 +118,11 @@ class HtmlCluster extends React.Component<Props, State> {
 
     return (
       <Map
-        style={outdoor}
+        mapStyle={outdoor}
         zoom={this.zoom}
         onStyleLoad={this.onStyleLoad}
         onMove={this.onMove}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
       >
         <Cluster ClusterMarkerFactory={this.clusterMarker}>
           {falls.features.map((feature: any, key: number) => (

--- a/example/src/demos/raws/htmlFeatures.raw
+++ b/example/src/demos/raws/htmlFeatures.raw
@@ -26,7 +26,7 @@ const Mark = styled.div`
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   width: '100%',
   height: '100%'
 };
@@ -112,8 +112,8 @@ class HtmlFeatures extends React.Component<Props, State> {
           options={options}
         />
         <Map
-          style={styles.light}
-          containerStyle={mapStyle}
+          mapStyle={styles.light}
+          style={mapContainerStyle}
           center={center}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/raws/londonCycle.raw
+++ b/example/src/demos/raws/londonCycle.raw
@@ -14,7 +14,7 @@ const Mapbox = ReactMapboxGl({
   accessToken: token
 });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -99,14 +99,14 @@ export default class LondonCycle extends React.Component<Props, State> {
 
     return (
       <Mapbox
-        style={styles.londonCycle}
+        mapStyle={styles.londonCycle}
         onStyleLoad={this.onStyleLoad}
         fitBounds={fitBounds}
         maxBounds={maxBounds}
         center={center}
         zoom={zoom}
         onDrag={this.onDrag}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         flyToOptions={flyToOptions}
       >
         <Layer type="symbol" id="marker" layout={layoutLayer} images={images}>

--- a/example/src/demos/raws/switchStyle.raw
+++ b/example/src/demos/raws/switchStyle.raw
@@ -45,7 +45,7 @@ const BottomBar = styled.div`
   align-items: center;
 `;
 
-const mapStyle = {
+const mapContainerStyle = {
   height: '100%',
   width: '100%'
 };
@@ -165,8 +165,8 @@ class StyleUpdate extends React.Component<Props, State> {
     return (
       <Container>
         <Map
-          style={styles[styleKey]}
-          containerStyle={mapStyle}
+          mapStyle={styles[styleKey]}
+          style={mapContainerStyle}
           center={mapCenter}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/raws/threeDMap.raw
+++ b/example/src/demos/raws/threeDMap.raw
@@ -6,7 +6,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -43,8 +43,8 @@ class ThreeDMap extends React.Component<Props, {}> {
   public render() {
     return (
       <Map
-        style={styles.light}
-        containerStyle={mapStyle}
+        mapStyle={styles.light}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
         zoom={this.zoom}
         center={this.center}

--- a/example/src/demos/switchStyle.tsx
+++ b/example/src/demos/switchStyle.tsx
@@ -45,7 +45,7 @@ const BottomBar = styled.div`
   align-items: center;
 `;
 
-const mapStyle = {
+const mapContainerStyle = {
   height: '100%',
   width: '100%'
 };
@@ -165,8 +165,8 @@ class StyleUpdate extends React.Component<Props, State> {
     return (
       <Container>
         <Map
-          style={styles[styleKey]}
-          containerStyle={mapStyle}
+          mapStyle={styles[styleKey]}
+          style={mapContainerStyle}
           center={mapCenter}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/threeDMap.tsx
+++ b/example/src/demos/threeDMap.tsx
@@ -6,7 +6,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -43,8 +43,8 @@ class ThreeDMap extends React.Component<Props, {}> {
   public render() {
     return (
       <Map
-        style={styles.light}
-        containerStyle={mapStyle}
+        mapStyle={styles.light}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
         zoom={this.zoom}
         center={this.center}

--- a/example/src/home-code.ts
+++ b/example/src/home-code.ts
@@ -4,9 +4,9 @@ const zoom = [8];
 
 render(
   <Map
-    style="mapbox://styles/mapbox/streets-v8"
+    mapStyle="mapbox://styles/mapbox/streets-v8"
     zoom={zoom}
-    containerStyle={{
+    style={{
       height: "100%",
       width: "500px"
     }}>

--- a/src/__tests__/map.test.tsx
+++ b/src/__tests__/map.test.tsx
@@ -31,7 +31,7 @@ describe('Map', () => {
 
   it('Should render the map correctly', () => {
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
-    mount(<MapboxMap style="" />);
+    mount(<MapboxMap mapStyle="" />);
   });
 
   it('Should call fitBounds with the right parameters', () => {
@@ -41,7 +41,7 @@ describe('Map', () => {
 
     mount(
       <MapboxMap
-        style=""
+        mapStyle=""
         fitBounds={fitBoundsValues}
         fitBoundsOptions={fitBoundsOptions}
       />
@@ -59,7 +59,7 @@ describe('Map', () => {
 
     const wrapper = mount(
       <MapboxMap
-        style=""
+        mapStyle=""
         fitBounds={fitBoundsValues}
         fitBoundsOptions={fitBoundsOptions}
       />
@@ -81,7 +81,7 @@ describe('Map', () => {
     const fitBoundsValues: FitBounds = [[0, 3], [2, 9]];
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
 
-    mount(<MapboxMap style="" fitBounds={fitBoundsValues} />);
+    mount(<MapboxMap mapStyle="" fitBounds={fitBoundsValues} />);
 
     const lastCall = mockMap.mock.calls[mockMap.mock.calls.length - 1];
     expect(lastCall[0].center).toEqual([1, 6]);
@@ -90,7 +90,7 @@ describe('Map', () => {
   it('Should listen onStyleLoad event', () => {
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
 
-    mount(<MapboxMap style="" onStyleLoad={jest.fn()} />);
+    mount(<MapboxMap mapStyle="" onStyleLoad={jest.fn()} />);
 
     expect(mockon).toBeCalledWith('load', jasmine.any(Function));
   });
@@ -100,7 +100,7 @@ describe('Map', () => {
     const center = [3, 4];
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
 
-    const wrapper = mount(<MapboxMap style="" center={[1, 2]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" center={[1, 2]} />);
 
     wrapper.setState({
       map: {
@@ -120,7 +120,7 @@ describe('Map', () => {
     const mockMaxBounds = jest.fn();
 
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
-    const wrapper = mount(<MapboxMap style="" />);
+    const wrapper = mount(<MapboxMap mapStyle="" />);
     wrapper.setState({
       map: {
         setMaxBounds: mockMaxBounds,
@@ -139,7 +139,7 @@ describe('Map', () => {
     const flyTo = jest.fn();
     const zoom: [number] = [3];
 
-    const wrapper = mount(<MapboxMap style="" zoom={zoom} />);
+    const wrapper = mount(<MapboxMap mapStyle="" zoom={zoom} />);
 
     wrapper.setState({
       map: {
@@ -156,7 +156,7 @@ describe('Map', () => {
     const flyTo = jest.fn();
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
 
-    const wrapper = mount(<MapboxMap style="" zoom={[1]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" zoom={[1]} />);
 
     wrapper.setState({
       map: {
@@ -175,7 +175,7 @@ describe('Map', () => {
     const flyTo = jest.fn();
     const bearing: [number] = [3];
 
-    const wrapper = mount(<MapboxMap style="" bearing={bearing} />);
+    const wrapper = mount(<MapboxMap mapStyle="" bearing={bearing} />);
 
     wrapper.setState({
       map: {
@@ -192,7 +192,7 @@ describe('Map', () => {
     const flyTo = jest.fn();
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
 
-    const wrapper = mount(<MapboxMap style="" bearing={[1]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" bearing={[1]} />);
 
     wrapper.setState({
       map: {
@@ -211,7 +211,7 @@ describe('Map', () => {
     const flyTo = jest.fn();
     const pitch: [number] = [3];
 
-    const wrapper = mount(<MapboxMap style="" pitch={pitch} />);
+    const wrapper = mount(<MapboxMap mapStyle="" pitch={pitch} />);
 
     wrapper.setState({
       map: {
@@ -228,7 +228,7 @@ describe('Map', () => {
     const flyTo = jest.fn();
     const MapboxMap = ReactMapboxGl({ accessToken: '' });
 
-    const wrapper = mount(<MapboxMap style="" pitch={[1]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" pitch={[1]} />);
 
     wrapper.setState({
       map: {
@@ -255,7 +255,7 @@ describe('Map', () => {
 
     const wrapper = mount(
       <MapboxMap
-        style=""
+        mapStyle=""
         zoom={zoom}
         flyToOptions={flyToOptions}
         animationOptions={animationOptions}

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -44,7 +44,7 @@ export interface FlyToOptions {
 
 // React Props updated between re-render
 export interface Props {
-  style: string | MapboxGl.Style;
+  mapStyle: string | MapboxGl.Style;
   center?: number[];
   zoom?: [number];
   maxBounds?: MapboxGl.LngLatBounds | FitBounds;
@@ -52,7 +52,7 @@ export interface Props {
   fitBoundsOptions?: FitBoundsOptions;
   bearing?: [number];
   pitch?: [number];
-  containerStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
   className?: string;
   movingMethod?: 'jumpTo' | 'easeTo' | 'flyTo';
   animationOptions?: Partial<AnimationOptions>;
@@ -176,7 +176,7 @@ const ReactMapboxFactory = ({
 
     public componentDidMount() {
       const {
-        style,
+        mapStyle,
         onStyleLoad,
         center,
         pitch,
@@ -212,7 +212,7 @@ const ReactMapboxFactory = ({
           fitBounds && center === defaultCenter
             ? this.calcCenter(fitBounds)
             : center,
-        style,
+        style: mapStyle,
         scrollZoom,
         attributionControl,
         interactive,
@@ -359,8 +359,8 @@ const ReactMapboxFactory = ({
         });
       }
 
-      if (!isEqual(this.props.style, nextProps.style)) {
-        map.setStyle(nextProps.style);
+      if (!isEqual(this.props.mapStyle, nextProps.mapStyle)) {
+        map.setStyle(nextProps.mapStyle);
       }
 
       return null;
@@ -371,14 +371,14 @@ const ReactMapboxFactory = ({
     };
 
     public render() {
-      const { containerStyle, className, children } = this.props;
+      const { style, className, children } = this.props;
       const { ready } = this.state;
 
       return (
         <div
           ref={this.setRef}
           className={className}
-          style={{ ...containerStyle, ...defaultContainerStyle }}
+          style={{ ...style, ...defaultContainerStyle }}
         >
           {ready && children}
         </div>


### PR DESCRIPTION
Fixes #498

## Breaking Changes
### Component Properties

- **style** &rightarrow; **mapStyle**
  - **style** has been renamed to **mapStyle** to avoid confusion with DOM styles.
- **containerStyle** &rightarrow; **style**
  - **containerStyle** has been renamed to **style** to adhere to standard React convention.
  - The **style** prop now controls the DOM styles for the container element.
