### PR TITLE
Fix issue where un-changed source will be re-added

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+const isEqual = require('deep-equal'); //tslint:disable-line
+
 import { Map, GeoJSONSource, GeoJSONSourceRaw, Layer } from 'mapbox-gl';
 import { SourceOptionData, TilesJson } from './util/types';
 
@@ -126,7 +128,7 @@ export default class Source extends React.Component<Props> {
       const hasNewTilesSource =
         tileJsonSource.url !== props.tileJsonSource.url ||
         // Check for reference equality on tiles array
-        tileJsonSource.tiles !== props.tileJsonSource.tiles ||
+        !isEqual(tileJsonSource.tiles, props.tileJsonSource.tiles) ||
         tileJsonSource.minzoom !== props.tileJsonSource.minzoom ||
         tileJsonSource.maxzoom !== props.tileJsonSource.maxzoom;
 


### PR DESCRIPTION
Mapbox-gl allows `tiles` to be an array instead of a string in order to rotate between multiple url endpoints. (for parallelizing requests)

We were running into an issue where the source would be re-added causing all tiles to be reloaded and flicker.

`deep-equal` works fine on strings and array so this is a simple fix.

Thanks.