### PR TITLE
allow manually setting a features geometry type

### DIFF
--- a/src/feature.ts
+++ b/src/feature.ts
@@ -4,6 +4,7 @@ import { AnyShapeCoordinates } from './util/types';
 export interface Props {
   // lat lng array (circle, line, symbol) or array of array... of lat lng (polygons)
   coordinates: AnyShapeCoordinates;
+  type: string;
   // tslint:disable-next-line:no-any
   properties?: any;
   onClick?: React.MouseEventHandler<HTMLElement>;

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -96,7 +96,14 @@ export default class Layer extends React.Component<Props> {
   };
 
   // tslint:disable-next-line:no-any
-  private geometry = (coordinates: any) => {
+  private geometry = (coordinates: any, type: string) => {
+    if (type) {
+      return {
+        type: type as string,
+        coordinates
+      };
+    }
+
     switch (this.props.type) {
       case 'symbol':
       case 'circle':
@@ -127,7 +134,7 @@ export default class Layer extends React.Component<Props> {
 
   private makeFeature = (props: FeatureProps, id: number): Feature => ({
     type: 'Feature',
-    geometry: this.geometry(props.coordinates),
+    geometry: this.geometry(props.coordinates, props.type),
     properties: { ...props.properties, id }
   });
 


### PR DESCRIPTION
This is needed because the auto geometry type selection does not work when you want to use both a line style and a fill style for a single polygon's coordinates