### PR TITLE
Resolves #567; Remove event listeners from unmounted Cluster component

### DIFF
--- a/src/cluster.tsx
+++ b/src/cluster.tsx
@@ -87,7 +87,14 @@ export default class Cluster extends React.Component<Props, State> {
     map.on('zoom', this.mapChange);
     this.mapChange();
   }
+  
+  public componentWillUnmount() {
+    const { map } = this.context;
 
+    map.off('move', this.mapChange);
+    map.off('zoom', this.mapChange);
+  }
+  
   public componentWillReceiveProps(nextProps: Props) {
     const { children } = this.props;
 

--- a/src/cluster.tsx
+++ b/src/cluster.tsx
@@ -87,14 +87,14 @@ export default class Cluster extends React.Component<Props, State> {
     map.on('zoom', this.mapChange);
     this.mapChange();
   }
-  
+
   public componentWillUnmount() {
     const { map } = this.context;
 
     map.off('move', this.mapChange);
     map.off('zoom', this.mapChange);
   }
-  
+
   public componentWillReceiveProps(nextProps: Props) {
     const { children } = this.props;
 


### PR DESCRIPTION
Remove event listeners from unmounted Cluster component in order to prevent warning logs in regard with attempt to 'setState' on unmounted Cluster component when 'zoom' or 'move' map events are triggered.