### PR TITLE
Type for handling subset of the Anchor keys at offset props

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -3,12 +3,12 @@ import ProjectedLayer from './projected-layer';
 import * as GeoJSON from 'geojson';
 import { getClassName } from './util/classname';
 import { Point } from 'mapbox-gl';
-import { Anchor } from './util/types';
+import { Anchor, OptionalOffset } from './util/types';
 
 export interface Props {
   coordinates: GeoJSON.Position;
   anchor?: Anchor;
-  offset?: number | number[] | Point;
+  offset?: number | number[] | Point | OptionalOffset;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onDoubleClick?: React.MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;

--- a/src/projected-layer.tsx
+++ b/src/projected-layer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { Map, Point } from 'mapbox-gl';
 import { OverlayParams, overlayState, overlayTransform } from './util/overlays';
-import { Anchor } from './util/types';
+import { Anchor, OptionalOffset } from './util/types';
 
 const defaultStyle = {
   zIndex: 3
@@ -12,7 +12,7 @@ export interface Props {
   type: 'marker' | 'popup';
   coordinates: number[];
   anchor?: Anchor;
-  offset?: number | number[] | Point;
+  offset?: number | number[] | Point | OptionalOffset;
   children?: JSX.Element | JSX.Element[];
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onDoubleClick?: React.MouseEventHandler<HTMLDivElement>;

--- a/src/util/overlays.ts
+++ b/src/util/overlays.ts
@@ -1,6 +1,6 @@
 import { LngLat, Point, Map } from 'mapbox-gl';
 import { Props } from '../projected-layer';
-import { Anchor, AnchorsOffset } from './types';
+import { Anchor, AnchorsOffset, OptionalOffset } from './types';
 
 export interface PointDef {
   x: number;
@@ -77,7 +77,7 @@ const calculateAnchor = (
 };
 
 const normalizedOffsets = (
-  offset?: number | Point | AnchorsOffset | number[]
+  offset?: number | Point | OptionalOffset | number[]
 ): AnchorsOffset => {
   if (!offset) {
     return normalizedOffsets(new Point(0, 0));

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -70,3 +70,7 @@ export type AnyShapeCoordinates =
   | number[][]
   | number[][][]
   | number[][][][];
+
+export type OptionalOffset = {
+  [P in Anchor]?: number[] | Point;
+}


### PR DESCRIPTION
The documentation of Popup says:

"When object is passed, it must contain keys for different anchor positions and values as the offset (number or number[])"
But the offset property type is the following:

```typescript
  offset?: number | number[] | Point;
```
We added the object type: OptionalOffset