### PR TITLE
preferredAnchor property

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -18,6 +18,7 @@ export interface Props {
   style?: React.CSSProperties;
   className?: string;
   tabIndex?: number;
+  preferredAnchor?: boolean;
 }
 
 export const defaultClassName = ['mapboxgl-popup'];

--- a/src/projected-layer.tsx
+++ b/src/projected-layer.tsx
@@ -23,6 +23,7 @@ export interface Props {
   style?: React.CSSProperties;
   className: string;
   tabIndex?: number;
+  preferredAnchor?: boolean;
 }
 
 export interface Context {


### PR DESCRIPTION
Currently there is no way to implement a good context menu on the map using `Popup` or `ProjectedLayer`, because if you set the `anchor` property to top-left, the popup uses that anchor even if the bottom of the popup is outside of the map.
We tried to solve this issue using an optional `preferredAnchor` boolean, which causes the anchor flip vertically or horizontally if needed