### PR TITLE
add duration to FitBoundsOptions

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -24,6 +24,7 @@ export interface FitBoundsOptions {
   padding?: number | PaddingOptions;
   offset?: MapboxGl.Point | number[];
   maxZoom?: number;
+  duration?: number;
 }
 
 export type FitBounds = number[][];


### PR DESCRIPTION
This option is part of `AnimationOptions` in mapbox-gl's docs but not listed under `fitBounds.options` for whatever reason. In any case, it actually works and was missing from this type here.