### PR TITLE
feat: update to mapbox-gl@0.48.0

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,7 +40,6 @@ const Map = ReactMapboxGl({
 - **dragPan** *(Default: `true`)*: `boolean` If  `true` , the "drag to pan" interaction is enabled (see DragPanHandler).
 - **refreshExpiredTiles** *(Default: `true`)*: `boolean` If  `false` , the map won't attempt to re-request tiles once they expire per their HTTP cacheControl / expires headers.
 - **failIfMajorPerformanceCaveat** *(Default: `false`)*: `boolean` If  `true` , map creation will fail if the performance of Mapbox GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
-- **classes**: `string[]` Mapbox style class names with which to initialize the map. Keep in mind that these classes are used for controlling a style layer's paint properties, so are not reflected in an HTML element's  class attribute. To learn more about Mapbox style classes, read about Layers in the style specification.
 - **bearingSnap** *(Default: `7`)*: `number` The threshold, measured in degrees, that determines when the map's bearing (rotation) will snap to north. For example, with a  bearingSnap of 7, if the user rotates the map within 7 degrees of north, the map will automatically snap to exact north.
 - **injectCss** *(Default: `true`)*: `boolean` If `false`, the factory will not try to inject the default CSS for the map into the `<head>` element.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,22 @@
         "wgs84": "0.0.0"
       }
     },
-    "@mapbox/gl-matrix": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz",
-      "integrity": "sha1-5RJqq01kw2uBx6l9CuDd3eV3PSs=",
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
+      "dev": true
+    },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
       "dev": true
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.3.0.tgz",
-      "integrity": "sha512-ACfuqIMxAzIoKRp3e7J2VjTJFBbrOoXqt4b7vy1x5uz5Od5Drroe2Ei/+R416eKpTXE1L0zHq5D2m3Q+SyM9WQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz",
+      "integrity": "sha512-ZD0Io4XK+/vU/4zpANjOtdWfVszAgnaMPsGR6LKsWh4kLIEv9qoobTVmJPPuwuM+ZI2b3BlZ6DYw1XHVmv6YTA==",
       "dev": true
     },
     "@mapbox/point-geometry": {
@@ -32,9 +38,9 @@
       "dev": true
     },
     "@mapbox/shelf-pack": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.1.0.tgz",
-      "integrity": "sha1-Ht6pwL9nFbIXFxumBkbCAa9SD2o=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.2.0.tgz",
+      "integrity": "sha512-dyQxe6ukILV6qaEvxoKCIwhblgRjYp1ZGlClo4xvfbmxzFO5LYu7Tnrg2AZrRgN7VsSragsGcNjzUe9kCdKHYQ==",
       "dev": true
     },
     "@mapbox/tiny-sdf": {
@@ -50,18 +56,18 @@
       "dev": true
     },
     "@mapbox/vector-tile": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.0.tgz",
-      "integrity": "sha1-xJX5clJb78zvzYOPRf+jfvO3D+g=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "dev": true,
       "requires": {
         "@mapbox/point-geometry": "0.1.0"
       }
     },
     "@mapbox/whoots-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.0.0.tgz",
-      "integrity": "sha1-wd5CkwgUJNo6wwwjr6hQrxAZu1Q=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
       "dev": true
     },
     "@turf/bbox": {
@@ -113,9 +119,9 @@
       }
     },
     "@types/geojson": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.3.tgz",
-      "integrity": "sha512-unWrGQhXRrNTk/MabfBLCM/rWT6zxR1OSK0GIPxsP8NX8mJcsNWkERPp4z0pTyHLiANy+Nwczf8Q2I16Pth1FA==",
+      "version": "7946.0.4",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
+      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
       "dev": true
     },
     "@types/jest": {
@@ -125,12 +131,12 @@
       "dev": true
     },
     "@types/mapbox-gl": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-0.42.0.tgz",
-      "integrity": "sha512-y+YjVbuzSB3W0qn0MexkhbqbhIM+s0iLHIA6u/gkyPx7O+br76ZIaebN/oWCA9lQAxSiDhWozs4ES80tjXGP3g==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-0.47.1.tgz",
+      "integrity": "sha512-AddVSRx+QB2m+iftM8zNvR5xsPGisl3AkHT1/nDa43qrRlPuk97f2md8w/U7nAsnp0nEFsjiw069ZLDEcanvoA==",
       "dev": true,
       "requires": {
-        "@types/geojson": "1.0.3"
+        "@types/geojson": "7946.0.4"
       }
     },
     "@types/node": {
@@ -182,14 +188,8 @@
       "integrity": "sha512-BSGVanlDm1+D3dcGKcy9pQurYAP1/5Jof9qkoyE8oYAxFEKIyUrieZ19V/B61Cw7N8eBy6bqtKGJK1YwbLSyEg==",
       "dev": true,
       "requires": {
-        "@types/geojson": "1.0.3"
+        "@types/geojson": "7946.0.4"
       }
-    },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
     },
     "abab": {
       "version": "1.0.3",
@@ -210,40 +210,6 @@
       "dev": true,
       "requires": {
         "acorn": "4.0.13"
-      }
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
-    },
-    "acorn-object-spread": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz",
-      "integrity": "sha1-SOrQ9KjrFplaF6Dbn/xqyq2kumg=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
       }
     },
     "ajv": {
@@ -289,6 +255,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
       "dev": true
     },
     "anymatch": {
@@ -683,14 +655,14 @@
       }
     },
     "brfs": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.4.tgz",
-      "integrity": "sha512-rX2qc9hkpLPiwdu1HkLY642rwwo3X6N+ZPyEPdNn3OUKV/B2BRP7dHdnkhGantOJLVoTluNYBi4VecHb2Kq2hw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+      "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
       "dev": true,
       "requires": {
         "quote-stream": "1.0.2",
         "resolve": "1.4.0",
-        "static-module": "2.1.1",
+        "static-module": "2.2.5",
         "through2": "2.0.3"
       }
     },
@@ -711,12 +683,6 @@
         }
       }
     },
-    "browserify-package-json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-package-json/-/browserify-package-json-1.0.1.tgz",
-      "integrity": "sha1-mN3oqlxWH9bT/km7qhArdLOW/eo=",
-      "dev": true
-    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -726,49 +692,16 @@
         "node-int64": "0.4.0"
       }
     },
-    "buble": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.15.2.tgz",
-      "integrity": "sha1-VH/EdIP45egXbYKqXrzLGDsC1hM=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0",
-        "acorn-jsx": "3.0.1",
-        "acorn-object-spread": "1.0.0",
-        "chalk": "1.1.3",
-        "magic-string": "0.14.0",
-        "minimist": "1.2.0",
-        "os-homedir": "1.0.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "bubleify": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-0.7.0.tgz",
-      "integrity": "sha1-0I6mQv/Qhf+HEciEP1cHLw1euPY=",
-      "dev": true,
-      "requires": {
-        "buble": "0.15.2",
-        "object-assign": "4.1.1"
-      }
-    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -776,32 +709,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "call-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        }
-      }
     },
     "callsites": {
       "version": "2.0.0",
@@ -815,6 +722,16 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
+    },
+    "cardinal": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
+      "dev": true,
+      "requires": {
+        "ansicolors": "0.2.1",
+        "redeyed": "0.4.4"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -934,11 +851,12 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
@@ -1351,23 +1269,6 @@
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
-    "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        }
-      }
-    },
     "estraverse": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -1529,20 +1430,17 @@
         }
       }
     },
+    "expect.js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.2.0.tgz",
+      "integrity": "sha1-EChTPSwcNj90pnlv9X7AUg3tK+E=",
+      "dev": true
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
-    },
-    "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "requires": {
-        "is-extendable": "0.1.1"
-      }
     },
     "extglob": {
       "version": "0.3.2",
@@ -1565,16 +1463,16 @@
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "dev": true,
       "requires": {
-        "acorn": "5.4.1",
+        "acorn": "5.7.2",
         "foreach": "2.0.5",
         "isarray": "0.0.1",
         "object-keys": "1.0.11"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
+          "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
           "dev": true
         },
         "isarray": {
@@ -1651,16 +1549,6 @@
       "dev": true,
       "requires": {
         "locate-path": "2.0.0"
-      }
-    },
-    "flow-remove-types": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-1.2.3.tgz",
-      "integrity": "sha512-ypq/U3V+t9atYiOuSJd40tekCra03EHKoRsiK/wXGrsZimuum0kdwVY7Yv0HTaoXgHW1WiayomYd+Q3kkvPl9Q==",
-      "dev": true,
-      "requires": {
-        "babylon": "6.18.0",
-        "vlq": "0.2.3"
       }
     },
     "for-in": {
@@ -2640,14 +2528,15 @@
       }
     },
     "geojson-rewind": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.3.0.tgz",
-      "integrity": "sha512-5dsjiZGk6p///Ju9kh7uGW+I74CZriHsxqBNPbIN4bbInfKmHwwM+f8fZ42fmpV5emeUYLTTC+GWs3EC1TMjNQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.3.1.tgz",
+      "integrity": "sha1-IiQHl8hHzC8MHTE+SqDJFa+n8p0=",
       "dev": true,
       "requires": {
         "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "1.6.0",
-        "minimist": "1.2.0"
+        "concat-stream": "1.6.2",
+        "minimist": "1.2.0",
+        "sharkdown": "0.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -2659,9 +2548,9 @@
       }
     },
     "geojson-vt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.0.0.tgz",
-      "integrity": "sha512-FL7VV56gYBDBh0F7EWyZV5G9/L2EHEHh9SyhEpJz4c8YDPerM6dnP9VbRcsbyg1wH+1oyoHRA9dlJkGs/IXULA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.0.tgz",
+      "integrity": "sha512-qk7sEv7dMfuGzflwClsgtO1fWPut/TqCInWEEUJc/Ofn4tmqBGznnPv3eUdxtwMkulMaAwSL3osHiyN03XJd/w==",
       "dev": true
     },
     "get-caller-file": {
@@ -2692,6 +2581,12 @@
           "dev": true
         }
       }
+    },
+    "gl-matrix": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.7.1.tgz",
+      "integrity": "sha512-22I6q7aO2oKNahNV0+9JavVNUhQXRTvR5jP2s8U1l93TkjcQe8RK6MeMYpM7+66R0sCVUgSdO97BL439vePyzQ==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -2737,36 +2632,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
-    },
-    "gray-matter": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
-      "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "js-yaml": "3.10.0",
-        "kind-of": "5.1.0",
-        "strip-bom-string": "1.0.0"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        }
-      }
     },
     "grid-index": {
       "version": "1.0.0",
@@ -2842,12 +2707,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
     },
     "has-flag": {
       "version": "1.0.0",
@@ -2949,9 +2808,9 @@
       "dev": true
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
     "imurmurhash": {
@@ -4141,16 +4000,6 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonlint-lines-primitives": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jsonlint-lines-primitives/-/jsonlint-lines-primitives-1.6.0.tgz",
-      "integrity": "sha1-u4n2DIubYS/ZE92qI2ZJuEDYZhE=",
-      "dev": true,
-      "requires": {
-        "JSV": "4.0.2",
-        "nomnom": "1.8.1"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4278,9 +4127,9 @@
       }
     },
     "magic-string": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.14.0.tgz",
-      "integrity": "sha1-VyJK7xcByu7Sc7F6OalW5ysXJGI=",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
         "vlq": "0.2.3"
@@ -4296,51 +4145,49 @@
       }
     },
     "mapbox-gl": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.44.0.tgz",
-      "integrity": "sha512-vMeZaLXjG1B1BKOD9HB11sb9UIUvbzXWJu0NR38j9Uyp1h5xUXqh1Rqe+EhxQp3jzlHIv/LVhFKCJjQQKA2LoA==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.48.0.tgz",
+      "integrity": "sha512-ck50tWMVkcxJzo43I9veqaox5xJBkx7h0EzS393DGGFFWs6IEhEGLvpybwTtw2if2V66tT2S02sYZy2zrmpJ9g==",
       "dev": true,
       "requires": {
-        "@mapbox/gl-matrix": "0.0.1",
-        "@mapbox/mapbox-gl-supported": "1.3.0",
+        "@mapbox/geojson-types": "1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "2.0.2",
+        "@mapbox/mapbox-gl-supported": "1.4.0",
         "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/shelf-pack": "3.1.0",
+        "@mapbox/shelf-pack": "3.2.0",
         "@mapbox/tiny-sdf": "1.1.0",
         "@mapbox/unitbezier": "0.0.0",
-        "@mapbox/vector-tile": "1.3.0",
-        "@mapbox/whoots-js": "3.0.0",
-        "brfs": "1.4.4",
-        "bubleify": "0.7.0",
+        "@mapbox/vector-tile": "1.3.1",
+        "@mapbox/whoots-js": "3.1.0",
+        "brfs": "1.6.1",
         "csscolorparser": "1.0.3",
         "earcut": "2.1.3",
-        "geojson-rewind": "0.3.0",
-        "geojson-vt": "3.0.0",
-        "gray-matter": "3.1.1",
+        "geojson-rewind": "0.3.1",
+        "geojson-vt": "3.2.0",
+        "gl-matrix": "2.7.1",
         "grid-index": "1.0.0",
-        "jsonlint-lines-primitives": "1.6.0",
         "minimist": "0.0.8",
-        "package-json-versionify": "1.0.4",
         "pbf": "3.1.0",
-        "quickselect": "1.0.1",
+        "quickselect": "1.1.1",
         "rw": "1.3.3",
-        "shuffle-seed": "1.1.6",
-        "sort-object": "0.3.2",
-        "supercluster": "2.3.0",
-        "through2": "2.0.3",
+        "supercluster": "4.1.1",
         "tinyqueue": "1.2.3",
-        "unassertify": "2.1.0",
-        "unflowify": "1.0.1",
-        "vt-pbf": "3.1.0",
-        "webworkify": "1.5.0"
+        "vt-pbf": "3.1.1"
       },
       "dependencies": {
+        "kdbush": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-2.0.1.tgz",
+          "integrity": "sha512-9KqSdmWCkBIisFIGclT0FRagKhI7IVbMyUjsxCFG0Ly1Dg6whlxJ7b9lrq8ifk3X/fGeJzok1R75LQfZTfA5zQ==",
+          "dev": true
+        },
         "supercluster": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-2.3.0.tgz",
-          "integrity": "sha1-h6tWCBu+qaHXJN9TUe6ejDry9Is=",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-4.1.1.tgz",
+          "integrity": "sha512-sF0FfUOPFp96DKzwWFLeQOEqqKu2PpcesxAFeFsknA/q7g7igVVn/p3NI2XHEghNSyDAqunKNKqAbqNO8+7NDQ==",
           "dev": true,
           "requires": {
-            "kdbush": "1.0.1"
+            "kdbush": "2.0.1"
           }
         }
       }
@@ -4359,6 +4206,15 @@
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
+    },
+    "merge-source-map": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -4431,26 +4287,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "multi-stage-sourcemap": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz",
-      "integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.1.43"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
     },
     "nan": {
       "version": "2.8.0",
@@ -4526,41 +4362,6 @@
         "semver": "5.4.1",
         "shellwords": "0.1.1",
         "which": "1.3.0"
-      }
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "dev": true,
-      "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        }
       }
     },
     "normalize-package-data": {
@@ -4780,15 +4581,6 @@
         "p-limit": "1.1.0"
       }
     },
-    "package-json-versionify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/package-json-versionify/-/package-json-versionify-1.0.4.tgz",
-      "integrity": "sha1-WGBYepRIc6a35tJujlH/siMVvxc=",
-      "dev": true,
-      "requires": {
-        "browserify-package-json": "1.0.1"
-      }
-    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -4857,8 +4649,8 @@
       "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
       "dev": true,
       "requires": {
-        "ieee754": "1.1.8",
-        "resolve-protobuf-schema": "2.0.0"
+        "ieee754": "1.1.12",
+        "resolve-protobuf-schema": "2.1.0"
       }
     },
     "performance-now": {
@@ -4974,9 +4766,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz",
-      "integrity": "sha1-0pxs1z+2VZePtpiWkRgNuEQRn2E=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
+      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w==",
       "dev": true
     },
     "prr": {
@@ -5004,9 +4796,9 @@
       "dev": true
     },
     "quickselect": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.0.1.tgz",
-      "integrity": "sha512-Jt30UQSzTbxf6L2bFTMabHtGtYUzQcvOY0a+s5brm8tzndV/XWifBIH9v5QKtH5gGCZ5RRDwRhdhGMDVHAEGNQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
       "dev": true
     },
     "quote-stream": {
@@ -5286,6 +5078,23 @@
         }
       }
     },
+    "redeyed": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
+      "dev": true,
+      "requires": {
+        "esprima": "1.0.4"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+          "dev": true
+        }
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
@@ -5380,12 +5189,12 @@
       }
     },
     "resolve-protobuf-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.0.0.tgz",
-      "integrity": "sha1-5nsGKmfwLRG9aIbnDv2niEB+D7Q=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "dev": true,
       "requires": {
-        "protocol-buffers-schema": "2.2.0"
+        "protocol-buffers-schema": "3.3.2"
       }
     },
     "ret": {
@@ -5475,12 +5284,6 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "seedrandom": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
-      "dev": true
-    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -5505,6 +5308,28 @@
       "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
       "dev": true
     },
+    "sharkdown": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.0.tgz",
+      "integrity": "sha1-YdT+Up510CRCEnzJI0NiJlCZIU8=",
+      "dev": true,
+      "requires": {
+        "cardinal": "0.4.4",
+        "expect.js": "0.2.0",
+        "minimist": "0.0.5",
+        "split": "0.2.10",
+        "stream-spigot": "2.1.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
+          "dev": true
+        }
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -5526,15 +5351,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "shuffle-seed": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/shuffle-seed/-/shuffle-seed-1.1.6.tgz",
-      "integrity": "sha1-UzwSaDurO0+j6HUfxOViFGdEJgs=",
-      "dev": true,
-      "requires": {
-        "seedrandom": "2.4.3"
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -5554,28 +5370,6 @@
       "dev": true,
       "requires": {
         "hoek": "2.16.3"
-      }
-    },
-    "sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "dev": true
-    },
-    "sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "dev": true
-    },
-    "sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dev": true,
-      "requires": {
-        "sort-asc": "0.1.0",
-        "sort-desc": "0.1.1"
       }
     },
     "source-map": {
@@ -5613,6 +5407,15 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
+    },
+    "split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -5654,16 +5457,19 @@
       }
     },
     "static-module": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.1.1.tgz",
-      "integrity": "sha512-PPLCnxRl74wV38rG1T0rH8Fl2wIktTXFo7/varrZjtSGb/vndZIGkpe4HJVd8hoBYXRkRHW6hlCRAHvmDgrYQQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+      "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
+        "convert-source-map": "1.5.1",
         "duplexer2": "0.1.4",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "falafel": "2.1.0",
         "has": "1.0.1",
+        "magic-string": "0.22.5",
+        "merge-source-map": "1.0.4",
         "object-inspect": "1.4.1",
         "quote-stream": "1.0.2",
         "readable-stream": "2.3.3",
@@ -5672,17 +5478,23 @@
         "through2": "2.0.3"
       },
       "dependencies": {
+        "convert-source-map": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "dev": true
+        },
         "escodegen": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-          "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
           "dev": true,
           "requires": {
             "esprima": "3.1.3",
             "estraverse": "4.2.0",
             "esutils": "2.0.2",
             "optionator": "0.8.2",
-            "source-map": "0.5.7"
+            "source-map": "0.6.1"
           }
         },
         "esprima": {
@@ -5695,6 +5507,48 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "stream-spigot": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/stream-spigot/-/stream-spigot-2.1.2.tgz",
+      "integrity": "sha1-feFF6Bn43Q20UJDRPc9zqO08wDU=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
@@ -5769,12 +5623,6 @@
       "requires": {
         "is-utf8": "0.2.1"
       }
-    },
-    "strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
-      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -6399,67 +6247,6 @@
       "dev": true,
       "optional": true
     },
-    "unassert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/unassert/-/unassert-1.5.1.tgz",
-      "integrity": "sha1-y8iOw4dBfFpeTALTzQe+mL11/3Y=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13",
-        "call-matcher": "1.0.1",
-        "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        }
-      }
-    },
-    "unassertify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unassertify/-/unassertify-2.1.0.tgz",
-      "integrity": "sha512-CB3C3vbOwrZydRuGdU8H421r4/qhM8RLuEOo3G+wEFf7kDP4TR+7oDuj1yOik5pUzXMaJmzxICM7akupP1AlJw==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.4.1",
-        "convert-source-map": "1.5.0",
-        "escodegen": "1.8.1",
-        "multi-stage-sourcemap": "0.2.1",
-        "through": "2.3.8",
-        "unassert": "1.5.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
-          "dev": true
-        }
-      }
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-      "dev": true
-    },
-    "unflowify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unflowify/-/unflowify-1.0.1.tgz",
-      "integrity": "sha1-ouoNJcCv/MRpVeZHNXX3xaH0ppY=",
-      "dev": true,
-      "requires": {
-        "flow-remove-types": "1.2.3",
-        "through": "2.3.8"
-      }
-    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -6514,13 +6301,13 @@
       "dev": true
     },
     "vt-pbf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.0.tgz",
-      "integrity": "sha512-UUCGPkpT1P/bm3R3/HX0SCnRSto44xXx0WuLFVG6C7KspdfQfU+84etoO6cITAGCdq8V5DjuWfDhvk/pyTyt3Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
+      "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
       "dev": true,
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "1.3.0",
+        "@mapbox/vector-tile": "1.3.1",
         "pbf": "3.1.0"
       }
     },
@@ -6537,12 +6324,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "webworkify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.5.0.tgz",
-      "integrity": "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==",
       "dev": true
     },
     "wgs84": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "supercluster": "3.0.2"
   },
   "peerDependencies": {
-    "mapbox-gl": "0.44.0",
+    "mapbox-gl": "0.48.0",
     "prop-types": "^15.5.10",
     "react": "^15.6.1 || ^16.0.0",
     "react-dom": "^15.6.1 || ^16.0.0"
@@ -73,9 +73,9 @@
     "@types/core-js": "0.9.43",
     "@types/deep-equal": "1.0.1",
     "@types/enzyme": "2.8.8",
-    "@types/geojson": "1.0.3",
+    "@types/geojson": "^7946.0.4",
     "@types/jest": "21.1.0",
-    "@types/mapbox-gl": "0.42.0",
+    "@types/mapbox-gl": "^0.47.1",
     "@types/node": "8.0.29",
     "@types/prettier": "1.10.0",
     "@types/prop-types": "15.5.2",
@@ -87,7 +87,7 @@
     "enzyme-adapter-react-16": "1.0.0",
     "husky": "^0.14.3",
     "jest": "21.2.0",
-    "mapbox-gl": "0.44.0",
+    "mapbox-gl": "0.48.0",
     "prettier": "1.10.2",
     "prop-types": "15.5.10",
     "react": "16.0.0",

--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -4,7 +4,7 @@ import * as MapboxGL from 'mapbox-gl';
 const isEqual = require('deep-equal'); //tslint:disable-line
 import diff from './util/diff';
 import { generateID } from './util/uid';
-import { Sources, SourceOptionData, Context, LayerType } from './util/types';
+import { Sources, Context, LayerType } from './util/types';
 
 const types = ['symbol', 'line', 'fill', 'fill-extrusion', 'circle'];
 const toCamelCase = (str: string) =>
@@ -90,7 +90,7 @@ export interface Props
     FillProps,
     FillExtrusionProps {
   id?: string;
-  data: SourceOptionData;
+  data: GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>;
   layerOptions?: MapboxGL.Layer;
   sourceOptions?:
     | MapboxGL.VectorSource

--- a/src/layer-events-hoc.tsx
+++ b/src/layer-events-hoc.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { Context, Feature } from './util/types';
+import { Context } from './util/types';
 import { Props as FeatureProps } from './feature';
 import { generateID } from './util/uid';
 import { LayerCommonProps, Props as LayerProps } from './layer';
@@ -57,7 +57,9 @@ function layerMouseTouchEvents(
 
     // tslint:disable-next-line:no-any
     public onClick = (evt: any) => {
-      const features = evt.features as Feature[];
+      const features = evt.features as Array<
+        GeoJSON.Feature<GeoJSON.GeometryObject, { id: number }>
+      >;
       const children = this.getChildren();
 
       const { map } = this.context;
@@ -84,16 +86,18 @@ function layerMouseTouchEvents(
       const { map } = this.context;
       this.hover = [];
 
-      evt.features.forEach((feature: Feature) => {
-        const { id } = feature.properties;
-        const child = this.getChildFromId(children, id);
-        this.hover.push(id);
+      evt.features.forEach(
+        (feature: GeoJSON.Feature<GeoJSON.GeometryObject, { id: number }>) => {
+          const { id } = feature.properties;
+          const child = this.getChildFromId(children, id);
+          this.hover.push(id);
 
-        const onMouseEnter = child && child.props.onMouseEnter;
-        if (onMouseEnter) {
-          onMouseEnter({ ...evt, feature, map });
+          const onMouseEnter = child && child.props.onMouseEnter;
+          if (onMouseEnter) {
+            onMouseEnter({ ...evt, feature, map });
+          }
         }
-      });
+      );
 
       if (this.areFeaturesDraggable(children)) {
         map.dragPan.disable();

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import * as MapboxGL from 'mapbox-gl';
 const isEqual = require('deep-equal'); //tslint:disable-line
 import diff from './util/diff';
-import { Feature, Context } from './util/types';
+import { Context } from './util/types';
 import { Props as FeatureProps } from './feature';
 
 export type Paint =
@@ -96,7 +96,7 @@ export default class Layer extends React.Component<Props> {
   };
 
   // tslint:disable-next-line:no-any
-  private geometry = (coordinates: any) => {
+  private geometry = (coordinates: any): GeoJSON.Geometry => {
     switch (this.props.type) {
       case 'symbol':
       case 'circle':
@@ -106,8 +106,14 @@ export default class Layer extends React.Component<Props> {
         };
 
       case 'fill':
+        if (coordinates.length > 1) {
+          return {
+            type: 'MultiPolygon',
+            coordinates
+          };
+        }
         return {
-          type: coordinates.length > 1 ? 'MultiPolygon' : 'Polygon',
+          type: 'Polygon',
           coordinates
         };
 
@@ -125,7 +131,10 @@ export default class Layer extends React.Component<Props> {
     }
   };
 
-  private makeFeature = (props: FeatureProps, id: number): Feature => ({
+  private makeFeature = (
+    props: FeatureProps,
+    id: number
+  ): GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties> => ({
     type: 'Feature',
     geometry: this.geometry(props.coordinates),
     properties: { ...props.properties, id }
@@ -313,7 +322,7 @@ export default class Layer extends React.Component<Props> {
     if (source && !sourceId && source.setData) {
       source.setData({
         type: 'FeatureCollection',
-        features
+        features: features as GeoJSON.Feature[]
       });
     }
 

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -93,7 +93,6 @@ export interface FactoryParameters {
   boxZoom?: boolean;
   refreshExpiredTiles?: boolean;
   failIfMajorPerformanceCaveat?: boolean;
-  classes?: string[];
   bearingSnap?: number;
   injectCss?: boolean;
   transformRequest?: RequestTransformFunction;
@@ -138,7 +137,6 @@ const ReactMapboxFactory = ({
   boxZoom = true,
   refreshExpiredTiles = true,
   failIfMajorPerformanceCaveat = false,
-  classes,
   bearingSnap = 7,
   injectCss = true,
   transformRequest
@@ -235,7 +233,6 @@ const ReactMapboxFactory = ({
         boxZoom,
         refreshExpiredTiles,
         logoPosition,
-        classes,
         bearingSnap,
         failIfMajorPerformanceCaveat,
         transformRequest

--- a/src/source.ts
+++ b/src/source.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { Map, GeoJSONSource, GeoJSONSourceRaw, Layer } from 'mapbox-gl';
-import { SourceOptionData, TilesJson } from './util/types';
+import { TilesJson } from './util/types';
 
 export interface Context {
   map: Map;
@@ -78,7 +78,7 @@ export default class Source extends React.Component<Props> {
     }
     // Will fix datasource being empty
     if (source && this.props.geoJsonSource && this.props.geoJsonSource.data) {
-      source.setData(this.props.geoJsonSource.data as SourceOptionData);
+      source.setData(this.props.geoJsonSource.data);
     }
     map.off('sourcedata', this.onData);
   };
@@ -143,10 +143,11 @@ export default class Source extends React.Component<Props> {
       geoJsonSource &&
       props.geoJsonSource &&
       props.geoJsonSource.data !== geoJsonSource.data &&
+      props.geoJsonSource.data &&
       map.getSource(this.id)
     ) {
       const source = map.getSource(this.id) as GeoJSONSource;
-      source.setData(props.geoJsonSource.data as SourceOptionData);
+      source.setData(props.geoJsonSource.data);
     }
   }
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -3,6 +3,7 @@ import {
   RasterSource,
   GeoJSONSource,
   GeoJSONSourceRaw,
+  RasterDemSource,
   ImageSource,
   VideoSource,
   Point,
@@ -33,22 +34,13 @@ export type Sources =
   | GeoJSONSource
   | GeoJSONSourceRaw
   | ImageSource
-  | VideoSource;
+  | VideoSource
+  | RasterDemSource;
 
 export type SourceOptionData =
   | GeoJSON.Feature<GeoJSON.GeometryObject>
   | GeoJSON.FeatureCollection<GeoJSON.GeometryObject>
   | string;
-
-export interface Feature {
-  type: 'Feature';
-  geometry: {
-    type: string;
-    coordinates: GeoJSON.Position;
-  };
-  // tslint:disable-next-line:no-any
-  properties: any;
-}
 
 export type TilesJson = VectorSource | RasterSource;
 


### PR DESCRIPTION
This drops the `classes` prop that's no longer supported by mapbox-gl. Other than that, no functional changes, only updates mapbox-gl and its types (0.48 isn't released for @types/mapbox-gl yet – pending PR – so can't implement those features here nicely).