### PR TITLE
Don't pass window to injectCSS

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -144,7 +144,7 @@ const ReactMapboxFactory = ({
   transformRequest
 }: FactoryParameters) => {
   if (injectCss) {
-    injectCSS(window);
+    injectCSS();
   }
 
   return class ReactMapboxGl extends React.Component<Props & Events, State> {

--- a/src/util/inject-css.ts
+++ b/src/util/inject-css.ts
@@ -1,6 +1,6 @@
 import cssRules from '../constants/css';
 
-const injectCSS = (window: Window) => {
+const injectCSS = () => {
   if (window && typeof window === 'object' && window.document) {
     const { document } = window;
     const head = document.head || document.getElementsByTagName('head')[0];

--- a/src/util/inject-css.ts
+++ b/src/util/inject-css.ts
@@ -1,7 +1,11 @@
 import cssRules from '../constants/css';
 
 const injectCSS = () => {
-  if (window && typeof window === 'object' && window.document) {
+  if (
+    typeof window !== 'undefined'
+    && typeof window === 'object'
+    && window.document
+  ) {
     const { document } = window;
     const head = document.head || document.getElementsByTagName('head')[0];
 


### PR DESCRIPTION
## Motivation
This is a low-hanging fruit in terms of making this library easier to use in a server context.

The `injectCSS` function references `window`, which is either a global variable in the frontend context or is undefined in the backend context. It makes more sense for injectCSS to reference it directly, as it's already making checks to see whether `window` conforms to the expected shape.

## Changes
* Remove window pass from map.tsx
* Add a check to ensure that window is not undefined before continuing to manipulate `window`