### PR TITLE
Fix layer rendering

### DIFF
--- a/src/__tests__/layer.test.tsx
+++ b/src/__tests__/layer.test.tsx
@@ -13,7 +13,7 @@ describe('Layer', () => {
     expect(mockMap.addLayer.mock.calls[0]).toEqual([
       {
         id: '1',
-        source: '1',
+        source: '1-source',
         type: 'symbol',
         layout: {},
         paint: {}
@@ -73,7 +73,7 @@ describe('Layer', () => {
     mount(<Layer id="1" map={mockMap as any} children={children} />);
 
     expect(mockMap.addSource.mock.calls[0]).toEqual([
-      '1',
+      '1-source',
       {
         type: 'geojson',
         data: {
@@ -108,14 +108,14 @@ describe('Layer', () => {
     );
 
     expect(mockMap.addSource.mock.calls[0]).toEqual([
-      layerSourceId,
+      layerSourceId + '-source',
       {
         type: 'geojson',
-        ...geoJSONSourceOptions,
         data: {
           type: 'FeatureCollection',
           features: []
-        }
+        },
+        ...geoJSONSourceOptions
       }
     ]);
   });

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -81,11 +81,11 @@ export default class Layer extends React.Component<Props> {
 
   private source: MapboxGL.GeoJSONSourceRaw = {
     type: 'geojson',
-    ...this.props.geoJSONSourceOptions,
     data: {
       type: 'FeatureCollection',
       features: []
-    }
+    },
+    ...this.props.geoJSONSourceOptions
   };
 
   // tslint:disable-next-line:no-any
@@ -150,9 +150,12 @@ export default class Layer extends React.Component<Props> {
     } = this.props;
     const { map } = this.props;
 
+    // This must be different from id of layer, otherwise it won't render
+    const generatedSourceId = id + '-source';
+
     const layer: MapboxGL.Layer = {
       id,
-      source: sourceId || id,
+      source: sourceId || generatedSourceId,
       // TODO: Fix mapbox-gl types
       // tslint:disable-next-line:no-any
       type: type as any,
@@ -185,7 +188,7 @@ export default class Layer extends React.Component<Props> {
     }
 
     if (!sourceId && !map.getSource(id)) {
-      map.addSource(id, this.source);
+      map.addSource(generatedSourceId, this.source);
     }
 
     if (!map.getLayer(id)) {


### PR DESCRIPTION
This PR fixes rendering of layers with geoJSONSourceOptions. The problem was two-fold:

- data has been overridden by default values, not the other way around (fixed test)
- generated sourceId was the same as layer id which apparently prevented it from being rendered

I used convention of appending `-source` to generated layer but I'm open for suggestions.