### PR TITLE
fix: Type mismatch in module augmentation for mapbox-gl

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -108,7 +108,7 @@ declare global {
   namespace mapboxgl {
     export interface MapboxOptions {
       failIfMajorPerformanceCaveat?: boolean;
-      transformRequest?: RequestTransformFunction;
+      transformRequest?: MapboxGl.TransformRequestFunction;
     }
   }
 }


### PR DESCRIPTION
Fixes #666 

I was running into this issues and was just overwriting the definition myself. I felt bad because others saw the same problem so I thought I'd try to be helpful and fix it. This library is great and I respect it a ton but I am new to contributing to it so if I can do anything to fix this issue in a better, or more sustainable way I'd be happy to help. Thanks.