### PR TITLE
Adding Image component

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -289,6 +289,31 @@ import { Feature } from "react-mapbox-gl";
 
 ---
 
+# Image
+
+Adds to the map a image that can be used as [`icon-image`](https://www.mapbox.com/mapbox-gl-js/style-spec#layout-symbol-icon-image)
+### How to use
+
+ Load local image. [see docs](https://www.mapbox.com/mapbox-gl-js/api#map#addimage)
+```jsx harmony
+<Image id={'image-uid'} data={someImage} />
+```
+
+ Load image from url. [see docs](https://www.mapbox.com/mapbox-gl-js/api#map#loadimage)
+```jsx harmony
+<Image id={'image-uid'} url={'url/to/image'} />
+```
+
+### Properties
+* **id** _(required)_: `string` the image name
+* **url** `string` A url to load the image from [see docs](https://www.mapbox.com/mapbox-gl-js/api#map#loadimage)
+* **data** `ImageDataType` The image data [see docs](https://www.mapbox.com/mapbox-gl-js/api#map#loadimage)
+* **options** `ImageOptionsType` The image options [see docs](https://www.mapbox.com/mapbox-gl-js/api#map#loadimage)
+* **onLoaded** `() => void` Will be called when image loaded to map
+* **onError** `(error: Error) => void` Will be called if image did not load 
+  
+---
+
 # ZoomControl
 
 A custom react zoom control component.

--- a/src/__tests__/image.test.tsx
+++ b/src/__tests__/image.test.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import Image from '../image';
+import { getMapMock } from '../jest/util';
+import { mount } from 'enzyme';
+
+describe('Image', () => {
+  it('Should add image on mount', () => {
+    const mapMock = getMapMock();
+    const onLoaded = jest.fn();
+    const onError = jest.fn();
+
+    const imageId = 'image';
+    const imageData = {};
+    const imageOptions = {};
+
+    mount(
+      <Image
+        id={imageId}
+        map={mapMock}
+        data={imageData}
+        options={imageOptions}
+        onError={onError}
+        onLoaded={onLoaded}
+      />
+    );
+
+    expect(mapMock.addImage.mock.calls[0]).toEqual([
+      imageId,
+      imageData,
+      imageOptions
+    ]);
+
+    expect(onLoaded).toBeCalled();
+    expect(onError).not.toBeCalled();
+  });
+
+  it('Should remove image on unmount', () => {
+    const mapMock = getMapMock();
+    const onLoaded = jest.fn();
+    const onError = jest.fn();
+
+    const imageId = 'image';
+    const imageData = {};
+    const imageOptions = {};
+
+    const component = mount(
+      <Image
+        id={imageId}
+        map={mapMock}
+        data={imageData}
+        options={imageOptions}
+        onError={onError}
+        onLoaded={onLoaded}
+      />
+    );
+
+    expect(mapMock.addImage).toBeCalled();
+    expect(onLoaded).toBeCalled();
+
+    component.unmount();
+    expect(mapMock.removeImage).toBeCalled();
+  });
+});

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { withMap } from './context';
+import { Map } from 'mapbox-gl';
+
+interface ImageOptionsType {
+  pixelRatio?: number;
+  sdf?: boolean;
+}
+
+type ImageDataType =
+  | HTMLImageElement
+  | ArrayBufferView
+  | { width: number; height: number; data: Uint8Array | Uint8ClampedArray }
+  | ImageData;
+
+export interface Props {
+  id: string;
+  url?: string;
+  data?: ImageDataType;
+  options?: ImageOptionsType;
+  onLoaded?: () => void;
+  onError?: (error: Error) => void;
+  map: Map;
+}
+
+class Image extends React.Component<Props> {
+  public componentWillMount() {
+    this.loadImage(this.props);
+  }
+
+  public componentWillUnmount() {
+    Image.removeImage(this.props);
+  }
+
+  public componentWillReceiveProps(nextProps: Props) {
+    const { id } = this.props;
+
+    if (nextProps.map !== this.props.map) {
+      // Remove image from old map
+      Image.removeImage(this.props);
+    }
+
+    if (nextProps.map && !nextProps.map.hasImage(id)) {
+      // Add missing image to map
+      this.loadImage(nextProps);
+    }
+  }
+
+  public render() {
+    return null;
+  }
+
+  private loadImage(props: Props) {
+    const { map, id, url, data, options, onError } = props;
+
+    if (data) {
+      map.addImage(id, data, options);
+      this.loaded();
+    } else if (url) {
+      map.loadImage(url, (error: Error | undefined, image: ImageDataType) => {
+        if (error) {
+          if (onError) {
+            onError(error);
+          }
+
+          return;
+        }
+        map.addImage(id, image, options);
+        this.loaded();
+      });
+    }
+  }
+
+  private static removeImage(props: Props) {
+    const { id, map } = props;
+    if (map) {
+      map.removeImage(id);
+    }
+  }
+  private loaded() {
+    const { onLoaded } = this.props;
+    if (onLoaded) {
+      onLoaded();
+    }
+  }
+}
+
+export default withMap(Image);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import Marker from './marker';
 import Source from './source';
 import Cluster from './cluster';
 import RotationControl from './rotation-control';
+import Image from './image';
 import { withMap } from './context';
 
 const Layer = withMap(layerMouseTouchEvents(BaseLayer));
@@ -26,7 +27,8 @@ export {
   Marker,
   Source,
   Cluster,
-  RotationControl
+  RotationControl,
+  Image
 };
 
 export default Map;

--- a/src/jest/util.tsx
+++ b/src/jest/util.tsx
@@ -13,6 +13,8 @@ export const getMapMock = (override?: { [key: string]: any }) => ({
   setLayerZoomRange: jest.fn(),
   getLayer: jest.fn(),
   addImage: jest.fn(),
+  loadImage: jest.fn(),
+  removeImage: jest.fn(),
   hasImage: jest.fn(),
   getSource: jest.fn().mockReturnValue({ setData: jest.fn() }),
   project: jest.fn(),


### PR DESCRIPTION
- [x] Has docs
- [X] Has tests

Adds an Image component as requested in #455 
The image will load to the map then it can be used as [`icon-image`](https://www.mapbox.com/mapbox-gl-js/style-spec#layout-symbol-icon-image)

Closes #455 
Closes #569