### PR TITLE
Fix Marker & Cluster mouse events

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -8,6 +8,7 @@ import {
   updateEvents
 } from './map-events';
 import { MapContext } from './context';
+import { createPortal } from 'react-dom';
 const isEqual = require('deep-equal'); //tslint:disable-line
 
 export interface PaddingOptions {
@@ -374,15 +375,19 @@ const ReactMapboxFactory = ({
 
     public render() {
       const { containerStyle, className, children } = this.props;
-      const { ready } = this.state;
+      const { ready, map } = this.state;
+      const container =
+        ready && map && typeof map.getCanvasContainer === 'function'
+          ? map.getCanvasContainer()
+          : undefined;
       return (
-        <MapContext.Provider value={this.state.map}>
+        <MapContext.Provider value={map}>
           <div
             ref={this.setRef}
             className={className}
             style={{ ...containerStyle }}
           >
-            {ready && children}
+            {ready && container && createPortal(children, container)}
           </div>
         </MapContext.Provider>
       );


### PR DESCRIPTION
This fix was original merged (via #619) into an early v4 branch which has been abandoned. Using `createPortal` fixes capturing move/scroll/zoom events on Marker & Cluster elements

Closes #217 (again)
Closes #562