### PR TITLE
Render markers into proper container

### DIFF
--- a/src/__tests__/cluster.test.tsx
+++ b/src/__tests__/cluster.test.tsx
@@ -65,7 +65,8 @@ describe('cluster', () => {
       getMapMock({
         getZoom: jest.fn(() => 2),
         getCanvas: jest.fn(() => ({ width: 1020, height: 800 })),
-        unproject: jest.fn(() => mockProjections[unprojectCalls++])
+        unproject: jest.fn(() => mockProjections[unprojectCalls++]),
+        getCanvasContainer: jest.fn()
       })
     );
 

--- a/src/projected-layer.tsx
+++ b/src/projected-layer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createPortal } from 'react-dom';
 import { Map, Point } from 'mapbox-gl';
 import { OverlayParams, overlayState, overlayTransform } from './util/overlays';
 import { Anchor } from './util/types';
@@ -82,6 +83,14 @@ export class ProjectedLayer extends React.Component<Props, OverlayParams> {
     map.off('move', this.handleMapMove);
   }
 
+  public renderIntoContainer(child: React.ReactNode): React.ReactNode {
+    if (this.props.type === 'marker') {
+      const container = this.props.map.getCanvasContainer();
+      return container ? createPortal(child, container) : child;
+    }
+    return child;
+  }
+
   public render() {
     const {
       style,
@@ -104,7 +113,7 @@ export class ProjectedLayer extends React.Component<Props, OverlayParams> {
     };
     const anchorClassname =
       anchor && type === 'popup' ? `mapboxgl-popup-anchor-${anchor}` : '';
-    return (
+    return this.renderIntoContainer(
       <div
         className={`${className} ${anchorClassname}`}
         onClick={onClick}


### PR DESCRIPTION
Currently markers are rendered outside of mapbox container which can cause lots of issues with proper styling of markers and managing their z-index. With this fix they are rendered inside canvas container and so it's much easier to keep them rendering within it and freely set map position, like `position: fixed`