### PR TITLE
Add the styleimagemissing event from mapbox

### DIFF
--- a/src/map-events.tsx
+++ b/src/map-events.tsx
@@ -36,6 +36,7 @@ export interface Events {
   onSourceData?: MapEvent;
   onDataLoading?: MapEvent;
   onStyleDataLoading?: MapEvent;
+  onStyleImageMissing?: MapEvent;
   onTouchCancel?: MapEvent;
   onData?: MapEvent;
   onSourceDataLoading?: MapEvent;
@@ -82,6 +83,7 @@ export const events: EventMapping = {
   onSourceData: 'sourcedata',
   onDataLoading: 'dataloading',
   onStyleDataLoading: 'styledataloading',
+  onStyleImageMissing: 'styleimagemissing',
   onTouchCancel: 'touchcancel',
   onData: 'data',
   onSourceDataLoading: 'sourcedataloading',
@@ -98,8 +100,8 @@ export const events: EventMapping = {
 };
 
 export type Listeners = {
-  [// tslint:disable-next-line:no-any
-  T in keyof Events]: (evt: React.SyntheticEvent<any>) => void
+  // tslint:disable-next-line:no-any
+  [T in keyof Events]: (evt: React.SyntheticEvent<any>) => void
 };
 
 export const listenEvents = (


### PR DESCRIPTION
This allows for things like the mapBox example here:
[Generate and add a missing icon to the map](https://docs.mapbox.com/mapbox-gl-js/example/add-image-missing-generated/)

For our purposes, that should allow us to have dynamic symbol images with presumably better performance than a large list of custom Marker components. 