### PR TITLE
Upgrade mapbox-gl from 0.54.0 to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,9 +66,9 @@
       "dev": true
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz",
-      "integrity": "sha512-ZD0Io4XK+/vU/4zpANjOtdWfVszAgnaMPsGR6LKsWh4kLIEv9qoobTVmJPPuwuM+ZI2b3BlZ6DYw1XHVmv6YTA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.1.tgz",
+      "integrity": "sha512-yyKza9S6z3ELKuf6w5n6VNUB0Osu6Z93RXPfMHLIlNWohu3KqxewLOq4lMXseYJ92GwkRAxd207Pr/Z98cwmvw==",
       "dev": true
     },
     "@mapbox/point-geometry": {
@@ -78,9 +78,9 @@
       "dev": true
     },
     "@mapbox/tiny-sdf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz",
-      "integrity": "sha512-dnhyk8X2BkDRWImgHILYAGgo+kuciNYX30CUKj/Qd5eNjh54OWM/mdOS/PWsPeN+3abtN+QDGYM4G220ynVJKA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
+      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg==",
       "dev": true
     },
     "@mapbox/unitbezier": {
@@ -4120,9 +4120,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.54.0.tgz",
-      "integrity": "sha512-wCcSlxO3wqYYo4nFXuR0HNi10Xkz2mYQ3szFAxYpWP1mzyC81f/u3HU5oa2JzJTWgSxkqQXTC9u48D0wO3PTfw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.1.1.tgz",
+      "integrity": "sha512-i57kASg8J/U/lJzBePyqTP2ImKUcx8FkHyCjb3ssWYaBBXHUeZ4STGXXfU9u1AQU9170PjDIJLubUUB1vLLSBQ==",
       "dev": true,
       "requires": {
         "@mapbox/geojson-rewind": "^0.4.0",
@@ -4158,9 +4158,9 @@
           "dev": true
         },
         "supercluster": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.1.tgz",
-          "integrity": "sha512-NTth/FBFUt9mwW03+Z6Byscex+UHu0utroIe6uXjGu9PrTuWtW70LYv9I1vPSYYIHQL74S5zAkrXrHEk0L7dGA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
+          "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
           "dev": true,
           "requires": {
             "kdbush": "^3.0.0"
@@ -6146,9 +6146,9 @@
       "dev": true
     },
     "tinyqueue": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.2.tgz",
-      "integrity": "sha512-1oUV+ZAQaeaf830ui/p5JZpzGBw46qs1pKHcfqIc6/QxYDQuEmcBLIhiT0xAxLnekz+qxQusubIYk4cAS8TB2A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "dev": true
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "supercluster": "3.0.2"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.54.0",
+    "mapbox-gl": "^1.1.1",
     "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-dom": "^16.5.2"
@@ -92,7 +92,7 @@
     "enzyme-adapter-react-16": "1.6.0",
     "husky": "^0.14.3",
     "jest": "23.6.0",
-    "mapbox-gl": "^0.54.0",
+    "mapbox-gl": "^1.1.1",
     "prettier": "1.10.2",
     "prop-types": "15.6.2",
     "react": "^16.8.6",


### PR DESCRIPTION
See issue #756 

While there are no _code_ related breaking changes from this upgrade, it does change the pricing model on Mapbox for anyone using this library. This change will be required as of November 20, 2019 either way.

See here for details: https://github.com/mapbox/mapbox-gl-js/blob/master/CHANGELOG.md