### PR TITLE
Rename unsafe lifecycle methods.

### DIFF
--- a/example/src/demos/allShapes.tsx
+++ b/example/src/demos/allShapes.tsx
@@ -77,7 +77,7 @@ class AllShapes extends React.Component<Props, State> {
   private timeoutHandle: any = undefined;
   private mounted = false;
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     this.mounted = true;
     this.timeoutHandle = setTimeout(() => {
       if (this.mounted) {

--- a/example/src/demos/londonCycle.tsx
+++ b/example/src/demos/londonCycle.tsx
@@ -60,7 +60,7 @@ export default class LondonCycle extends React.Component<Props, State> {
     stations: {}
   };
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     getCycleStations().then(res => {
       this.setState(({ stations }) => ({
         stations: {

--- a/example/src/demos/raws/allShapes.raw
+++ b/example/src/demos/raws/allShapes.raw
@@ -77,7 +77,7 @@ class AllShapes extends React.Component<Props, State> {
   private timeoutHandle: any = undefined;
   private mounted = false;
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     this.mounted = true;
     this.timeoutHandle = setTimeout(() => {
       if (this.mounted) {

--- a/example/src/demos/raws/londonCycle.raw
+++ b/example/src/demos/raws/londonCycle.raw
@@ -60,7 +60,7 @@ export default class LondonCycle extends React.Component<Props, State> {
     stations: {}
   };
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     getCycleStations().then(res => {
       this.setState(({ stations }) => ({
         stations: {

--- a/example/src/demos/raws/switchStyle.raw
+++ b/example/src/demos/raws/switchStyle.raw
@@ -101,7 +101,7 @@ class StyleUpdate extends React.Component<Props, State> {
     renderLayer: true
   };
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     navigator.geolocation.getCurrentPosition(
       ({ coords }: any) => {
         const { latitude, longitude } = coords;

--- a/example/src/demos/switchStyle.tsx
+++ b/example/src/demos/switchStyle.tsx
@@ -101,7 +101,7 @@ class StyleUpdate extends React.Component<Props, State> {
     renderLayer: true
   };
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     navigator.geolocation.getCurrentPosition(
       ({ coords }: any) => {
         const { latitude, longitude } = coords;

--- a/example/src/root.tsx
+++ b/example/src/root.tsx
@@ -53,7 +53,7 @@ export default class Root extends React.Component<RouteComponentProps<void, void
     selected: paths.indexOf(this.props.location.pathname)
   }
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     browserHistory.listen(ev => {
       this.setState({
         selected: paths.indexOf(ev.pathname)

--- a/src/cluster.tsx
+++ b/src/cluster.tsx
@@ -65,7 +65,7 @@ export class Cluster extends React.Component<Props, State> {
     React.ReactElement<MarkerProps>
   >();
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     const { children, map } = this.props;
 
     if (children) {
@@ -84,7 +84,7 @@ export class Cluster extends React.Component<Props, State> {
     map.off('zoom', this.mapChange);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { children } = this.props;
 
     if (children !== nextProps.children && nextProps.children) {

--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -235,7 +235,7 @@ export class GeoJSONLayer extends React.Component<Props> {
     });
   }
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     const { map } = this.props;
     this.initialize();
     map.on('styledata', this.onStyleDataChange);
@@ -259,7 +259,7 @@ export class GeoJSONLayer extends React.Component<Props> {
     !!source &&
     typeof (source as MapboxGL.GeoJSONSource).setData === 'function';
 
-  public componentWillReceiveProps(props: Props) {
+  public UNSAFE_componentWillReceiveProps(props: Props) {
     const { data, before, layerOptions, map } = this.props;
     const source = map.getSource(this.id);
     if (!this.isGeoJSONSource(source)) {

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -24,7 +24,7 @@ export interface Props {
 }
 
 class Image extends React.Component<Props> {
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     this.loadImage(this.props);
   }
 
@@ -32,7 +32,7 @@ class Image extends React.Component<Props> {
     Image.removeImage(this.props);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { id } = this.props;
 
     if (nextProps.map !== this.props.map) {

--- a/src/layer-events-hoc.tsx
+++ b/src/layer-events-hoc.tsx
@@ -215,7 +215,7 @@ export function layerMouseTouchEvents(
       this.draggedChildren = undefined;
     };
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
       const { map } = this.props;
 
       map.on('click', this.id, this.onClick);

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -238,7 +238,7 @@ export default class Layer extends React.Component<Props> {
     }
   };
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     const { map } = this.props;
 
     this.initialize();
@@ -282,7 +282,7 @@ export default class Layer extends React.Component<Props> {
     }
   }
 
-  public componentWillReceiveProps(props: Props) {
+  public UNSAFE_componentWillReceiveProps(props: Props) {
     const { paint, layout, before, filter, id, minZoom, maxZoom } = this.props;
     const { map } = this.props;
 

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -288,7 +288,7 @@ const ReactMapboxFactory = ({
       }
     }
 
-    public componentWillReceiveProps(nextProps: Props & Events) {
+    public UNSAFE_componentWillReceiveProps(nextProps: Props & Events) {
       const { map } = this.state;
       if (!map) {
         return null;

--- a/src/projected-layer.tsx
+++ b/src/projected-layer.tsx
@@ -68,7 +68,7 @@ export class ProjectedLayer extends React.Component<Props, OverlayParams> {
     );
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.havePropsChanged(this.props, nextProps)) {
       this.setState(overlayState(nextProps, this.props.map, this.container!));
     }

--- a/src/scale-control.tsx
+++ b/src/scale-control.tsx
@@ -91,7 +91,7 @@ export class ScaleControl extends React.Component<Props, State> {
     scaleWidth: MIN_WIDTH_SCALE
   };
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     this.setScale();
 
     this.props.map.on('zoomend', this.setScale);

--- a/src/source.ts
+++ b/src/source.ts
@@ -28,7 +28,7 @@ export class Source extends React.Component<Props> {
     }
   };
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     const { map } = this.props;
 
     map.on('styledata', this.onStyleDataChange);
@@ -106,7 +106,7 @@ export class Source extends React.Component<Props> {
     this.removeSource();
   }
 
-  public componentWillReceiveProps(props: Props) {
+  public UNSAFE_componentWillReceiveProps(props: Props) {
     const { geoJsonSource, tileJsonSource, map } = this.props;
 
     // Update tilesJsonSource


### PR DESCRIPTION
After updating to React v16.9.0 the console is cluttered with warnings about the deprecated use of unsafe lifecycle methods (`componentWillMount`, `componentWillReceiveProps`, `componentWillUpdate`).

The old names will still work in upcoming 16.x and 17.x releases, but in order to let them stand out (and get rid of the console warnings) they have to be prefixed with `UNSAFE_`.

https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods