### PR TITLE
Fix 652 and 603 by adding an id to the geojson feature for Layer component and prevent creating as many layers as there are layer types for geojsonLayer component

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -246,6 +246,7 @@ import { GeoJSONLayer } from "react-mapbox-gl";
 ### Properties
 
 * **data** _(required)_: `string | object` The url to the geojson file or the geojson file itself.
+* **id**: `string` An id to give to the source.
 * **lineLayout** | **symbolLayout** | **circleLayout** | **fillLayout** | **fillExtrusionLayout**: `Object` Layer layout information. [mapbox layout api](https://www.mapbox.com/mapbox-gl-style-spec/#layer-layout)
 * **linePaint** | **symbolPaint** | **circlePaint** | **fillPaint** | **fillExtrusionPaint**: `Object` Paint information. [mapbox paint api](https://www.mapbox.com/mapbox-gl-style-spec/#layer-paint)
 * **lineOnMouseDown** | **symbolOnMouseDown** | **circleOnMouseDown** | **fillOnMouseDown** | **fillExtrusionOnMouseDown**: `function` Mouse down handler. [mapbox map mouse event](https://www.mapbox.com/mapbox-gl-js/api/#mapmouseevent)

--- a/src/__tests__/layer.test.tsx
+++ b/src/__tests__/layer.test.tsx
@@ -137,7 +137,8 @@ describe('Layer', () => {
           {
             geometry: { ...feature, type: 'Point' },
             properties: { id: 0 },
-            type: 'Feature'
+            type: 'Feature',
+            id: 0
           }
         ]
       }

--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -137,6 +137,10 @@ export class GeoJSONLayer extends React.Component<Props> {
   private createLayer = (type: LayerType) => {
     const { before, layerOptions, map } = this.props;
 
+    if (layerOptions && layerOptions.type && layerOptions.type !== type) {
+      return;
+    }
+
     const layerId = this.buildLayerId(type);
     this.layerIds.push(layerId);
 

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -155,7 +155,8 @@ export default class Layer extends React.Component<Props> {
   ): GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties> => ({
     type: 'Feature',
     geometry: this.geometry(props.coordinates),
-    properties: { ...props.properties, id }
+    properties: { ...props.properties, id },
+    id
   });
 
   private initialize = () => {


### PR DESCRIPTION
**As mentioned in #652 :**
An id was missing in the geojson features that was preventing to use this kind of feature: https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/
I added the same id to the feature than the one that was added to the feature properties:
```
{
    type: 'Feature',
    geometry: this.geometry(props.coordinates),
    properties: { ...props.properties, id },
    id
}
```
The example code that were not working in the issue is now working fine

**As mentioned in #603 :**
Passing `layerOptions` props with and `id` to the `GeoJSONLayer` component was not working.
It was because in the `initialize` function, a layer was created for each layer type, even if it was stated that it should be one precise type:
```
this.createLayer('symbol');
this.createLayer('line');
this.createLayer('fill');
this.createLayer('fill-extrusion');
this.createLayer('circle');
```
I added a check to create the layer only if the layer type is the right one.
```
if (layerOptions && layerOptions.type && layerOptions.type !== type) {
      return;
}
```
Note that I also documented the `id` props of the `GeoJSONLayer` component that was missing.
