### PR TITLE
add antialias support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -48,6 +48,7 @@ const Map = ReactMapboxGl({
 * **refreshExpiredTiles** _(Default: `true`)_: `boolean` If `false` , the map won't attempt to re-request tiles once they expire per their HTTP cacheControl / expires headers.
 * **failIfMajorPerformanceCaveat** _(Default: `false`)_: `boolean` If `true` , map creation will fail if the performance of Mapbox GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
 * **bearingSnap** _(Default: `7`)_: `number` The threshold, measured in degrees, that determines when the map's bearing (rotation) will snap to north. For example, with a bearingSnap of 7, if the user rotates the map within 7 degrees of north, the map will automatically snap to exact north.
+* **antialias** _(Default: `false`)_: `boolean` If  true, the gl context will be created with MSA antialiasing, which can be useful for antialiasing custom layers. This is false by default as a performance optimization.
 
 ### Component Properties
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,9 +172,9 @@
       "dev": true
     },
     "@types/mapbox-gl": {
-      "version": "0.51.6",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-0.51.6.tgz",
-      "integrity": "sha512-CvOYB4MfqDQm3YH6Xr7odn8qK3zvOPAySXi2/lNmZDc1CdofIa6NdVOwKP2+WP8XD4hEiFr91PBuuNstsfTm0A==",
+      "version": "0.54.3",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-0.54.3.tgz",
+      "integrity": "sha512-/G06vUcV5ucNB7G9ka6J+VbGtffyUYvfe6A3oae/+csTlHIEHcvyJop3Ic4yeMDxycsQCmBvuwz+owseMuiQ3w==",
       "dev": true,
       "requires": {
         "@types/geojson": "*"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/geojson": "7946.0.4",
     "@types/jest": "23.3.5",
-    "@types/mapbox-gl": "^0.51.6",
+    "@types/mapbox-gl": "^0.54.3",
     "@types/node": "8.0.29",
     "@types/prettier": "1.10.0",
     "@types/prop-types": "15.5.6",

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -99,6 +99,7 @@ export interface FactoryParameters {
   bearingSnap?: number;
   injectCSS?: boolean;
   transformRequest?: RequestTransformFunction;
+  antialias?: boolean;
 }
 
 // Satisfy typescript pitfall with defaultProps
@@ -141,6 +142,7 @@ const ReactMapboxFactory = ({
   failIfMajorPerformanceCaveat = false,
   bearingSnap = 7,
   injectCSS = true,
+  antialias = false,
   transformRequest
 }: FactoryParameters) => {
   if (injectCSS) {
@@ -235,6 +237,7 @@ const ReactMapboxFactory = ({
         logoPosition,
         bearingSnap,
         failIfMajorPerformanceCaveat,
+        antialias,
         transformRequest
       };
 


### PR DESCRIPTION
add `antialias` property (by default: `false`)
added to mapbox-gl-js in [v0.54.0](https://github.com/mapbox/mapbox-gl-js/releases/tag/v0.54.0)