### PR TITLE
Update Mapbox from v1.1.1 to v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mapbox-gl",
-  "version": "4.7.0",
+  "version": "4.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4125,26 +4125,11 @@
         "vt-pbf": "^3.1.1"
       },
       "dependencies": {
-        "kdbush": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-          "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
-          "dev": true
-        },
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
-        },
-        "supercluster": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
-          "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
-          "dev": true,
-          "requires": {
-            "kdbush": "^3.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "supercluster": "^6.0.2"
   },
   "peerDependencies": {
-    "mapbox-gl": "^1.1.1",
+    "mapbox-gl": "^1.4.1",
     "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-dom": "^16.5.2"
@@ -94,7 +94,7 @@
     "enzyme-adapter-react-16": "1.6.0",
     "husky": "^0.14.3",
     "jest": "24.9.0",
-    "mapbox-gl": "^1.1.1",
+    "mapbox-gl": "^1.4.1",
     "prettier": "1.10.2",
     "prop-types": "15.6.2",
     "react": "^16.8.6",


### PR DESCRIPTION
This PR updates the mapbox-gl dependency from 1.1.1 to 1.4.1.

Mapbox added these features in v1.4.0 which can prove handy especially for labels:

- Add image expression operator to determine image availability (#8684)
- Enable text-offset with variable label placement (#8642)

As well is these in v1.3.0

- Introduce text-writing-mode symbol layer property to allow placing point labels vertically. #8399
- Extend variable text placement to work when text/icon-allow-overlap is set to true. #8620
- Allow text-color to be used in formatted expressions to be able to draw different parts of a label in different colors. #8068