### PR TITLE
Fix geojson layer layerid conflict

### DIFF
--- a/src/__tests__/geojson-layer.test.tsx
+++ b/src/__tests__/geojson-layer.test.tsx
@@ -68,4 +68,60 @@ describe('GeoJSONLayer', () => {
     expect(mapMock.on.mock.calls[0][0]).toEqual('click');
     expect(mapMock.on.mock.calls[0][1]).toEqual('geojson-3-fill');
   });
+
+  it('Should mount new source if source id does not exist', () => {
+    const noMatchingSourceFound = void 0;
+
+    const mapMock = getMapMock({ getSource: jest.fn().mockReturnValue(noMatchingSourceFound)});
+
+    const GeoJSONLayerComp = (
+      <GeoJSONLayer
+        layer
+        fillPaint={fillPaint}
+        data={data}
+      />
+    );
+
+    mountWithMap(GeoJSONLayerComp, mapMock);
+
+    expect(mapMock.getSource).toBeCalled();
+    expect(mapMock.addSource).toBeCalled();
+  })
+
+  it('Should not mount new source if source id exists', () => {
+    const mapMock = getMapMock();
+
+    const GeoJSONLayerComp = (
+      <GeoJSONLayer
+        fillPaint={fillPaint}
+        data={data}
+      />
+    );
+
+    mountWithMap(GeoJSONLayerComp, mapMock);
+
+    expect(mapMock.getSource).toBeCalled();
+    expect(mapMock.addSource).not.toBeCalled();
+  })
+
+  it('Should should update existing source on mount if source id exists', () => {
+    const setDataMock = jest.fn();
+    const getSourceReturn = { setData: setDataMock };
+    const mapMock = getMapMock({ getSource: jest.fn().mockReturnValue(getSourceReturn) });
+
+    const GeoJSONLayerComp = (
+      <GeoJSONLayer
+        fillPaint={fillPaint}
+        data={data}
+      />
+    );
+
+    mountWithMap(GeoJSONLayerComp, mapMock);
+
+    expect(mapMock.getSource).toBeCalled();
+    expect(mapMock.getSource).toReturnWith(getSourceReturn);
+    expect(setDataMock).toBeCalled();
+
+    expect(mapMock.addSource).not.toBeCalled();
+  })
 });

--- a/src/__tests__/geojson-layer.test.tsx
+++ b/src/__tests__/geojson-layer.test.tsx
@@ -72,49 +72,39 @@ describe('GeoJSONLayer', () => {
   it('Should mount new source if source id does not exist', () => {
     const noMatchingSourceFound = void 0;
 
-    const mapMock = getMapMock({ getSource: jest.fn().mockReturnValue(noMatchingSourceFound)});
+    const mapMock = getMapMock({
+      getSource: jest.fn().mockReturnValue(noMatchingSourceFound)
+    });
 
     const GeoJSONLayerComp = (
-      <GeoJSONLayer
-        layer
-        fillPaint={fillPaint}
-        data={data}
-      />
+      <GeoJSONLayer layer fillPaint={fillPaint} data={data} />
     );
 
     mountWithMap(GeoJSONLayerComp, mapMock);
 
     expect(mapMock.getSource).toBeCalled();
     expect(mapMock.addSource).toBeCalled();
-  })
+  });
 
   it('Should not mount new source if source id exists', () => {
     const mapMock = getMapMock();
 
-    const GeoJSONLayerComp = (
-      <GeoJSONLayer
-        fillPaint={fillPaint}
-        data={data}
-      />
-    );
+    const GeoJSONLayerComp = <GeoJSONLayer fillPaint={fillPaint} data={data} />;
 
     mountWithMap(GeoJSONLayerComp, mapMock);
 
     expect(mapMock.getSource).toBeCalled();
     expect(mapMock.addSource).not.toBeCalled();
-  })
+  });
 
   it('Should should update existing source on mount if source id exists', () => {
     const setDataMock = jest.fn();
     const getSourceReturn = { setData: setDataMock };
-    const mapMock = getMapMock({ getSource: jest.fn().mockReturnValue(getSourceReturn) });
+    const mapMock = getMapMock({
+      getSource: jest.fn().mockReturnValue(getSourceReturn)
+    });
 
-    const GeoJSONLayerComp = (
-      <GeoJSONLayer
-        fillPaint={fillPaint}
-        data={data}
-      />
-    );
+    const GeoJSONLayerComp = <GeoJSONLayer fillPaint={fillPaint} data={data} />;
 
     mountWithMap(GeoJSONLayerComp, mapMock);
 
@@ -123,5 +113,5 @@ describe('GeoJSONLayer', () => {
     expect(setDataMock).toBeCalled();
 
     expect(mapMock.addSource).not.toBeCalled();
-  })
+  });
 });

--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -193,7 +193,19 @@ export class GeoJSONLayer extends React.Component<Props> {
   private initialize() {
     const { map } = this.props;
 
-    map.addSource(this.id, this.source);
+    const existingSource = map.getSource(this.id);
+
+    if (existingSource) {
+      if ('setData' in existingSource) {
+        // Type conflict: Source is not assignable if vector source
+        // But this is a GeoJSON component andvector source does not 
+        // return a setData method, so this will never be a concern
+        // @ts-ignore
+        existingSource.setData(this.source)
+      }
+    } else {
+      map.addSource(this.id, this.source);
+    }
 
     this.createLayer('symbol');
     this.createLayer('line');

--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -198,10 +198,10 @@ export class GeoJSONLayer extends React.Component<Props> {
     if (existingSource) {
       if ('setData' in existingSource) {
         // Type conflict: Source is not assignable if vector source
-        // But this is a GeoJSON component andvector source does not 
+        // But this is a GeoJSON component andvector source does not
         // return a setData method, so this will never be a concern
         // @ts-ignore
-        existingSource.setData(this.source)
+        existingSource.setData(this.source);
       }
     } else {
       map.addSource(this.id, this.source);

--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -198,7 +198,7 @@ export class GeoJSONLayer extends React.Component<Props> {
     if (existingSource) {
       if ('setData' in existingSource) {
         // Type conflict: Source is not assignable if vector source
-        // But this is a GeoJSON component andvector source does not
+        // But this is a GeoJSON component and vector source does not
         // return a setData method, so this will never be a concern
         // @ts-ignore
         existingSource.setData(this.source);


### PR DESCRIPTION
If the GeoJSONLayer component remounts without the map also re-initializing, existing sources persist in mapbox-gl js. The existing GeoJSONLayer implementation adds a source on initialization without checking for existing sources, which causes an uncaught error:

```
Uncaught Error: There is already a source with this ID
    at i.addSource (mapbox-gl.js:33)
    at r.addSource (mapbox-gl.js:33)
    at GeoJSONLayer.initialize (geojson-layer.ts:196)
    at GeoJSONLayer.UNSAFE_componentWillMount (geojson-layer.ts:240)
```

The Layer component already performs this check in its initialize method:
```
if (!sourceId && !map.getSource(id)) {
  map.addSource(id, this.source);
}
```
I've added a similar check for the GeoJSONLayer component.