### PR TITLE
Fix existing image error

### DIFF
--- a/src/__tests__/image.test.tsx
+++ b/src/__tests__/image.test.tsx
@@ -91,4 +91,94 @@ describe('Image', () => {
     component.unmount();
     expect(mapMock.removeImage).not.toBeCalled();
   });
+
+  it('Should not add image if image id already exists', () => {
+    const imageExists = jest.fn().mockReturnValue(true);
+    const updateImage = jest.fn();
+
+    const mapMock = getMapMock({ hasImage: imageExists, updateImage });
+    const onLoaded = jest.fn();
+    const onError = jest.fn();
+
+    const imageId = 'image';
+    const imageData = {};
+    const imageOptions = {};
+
+    mount(
+      <Image
+        id={imageId}
+        map={mapMock}
+        data={imageData}
+        options={imageOptions}
+        onError={onError}
+        onLoaded={onLoaded}
+      />
+    );
+
+    expect(mapMock.hasImage).toBeCalled();
+    expect(mapMock.addImage).not.toBeCalled();
+
+    expect(onLoaded).toBeCalled();
+    expect(onError).not.toBeCalled();
+  });
+
+  it('Should update image if image id does exist', () => {
+    const imageExists = jest.fn().mockReturnValue(true);
+    const updateImage = jest.fn();
+
+    const mapMock = getMapMock({ hasImage: imageExists, updateImage });
+    const onLoaded = jest.fn();
+    const onError = jest.fn();
+
+    const imageId = 'image';
+    const imageData = {};
+    const imageOptions = {};
+
+    mount(
+      <Image
+        id={imageId}
+        map={mapMock}
+        data={imageData}
+        options={imageOptions}
+        onError={onError}
+        onLoaded={onLoaded}
+      />
+    );
+
+    expect(mapMock.hasImage).toBeCalled();
+    expect(mapMock.addImage).not.toBeCalled();
+    expect(updateImage).toBeCalled();
+
+    expect(onLoaded).toBeCalled();
+    expect(onError).not.toBeCalled();
+  });
+
+  it('Should add image if image id does not exist', () => {
+    const imageDoesNotExist = jest.fn().mockReturnValue(false);
+
+    const mapMock = getMapMock({ hasImage: imageDoesNotExist });
+    const onLoaded = jest.fn();
+    const onError = jest.fn();
+
+    const imageId = 'image';
+    const imageData = {};
+    const imageOptions = {};
+
+    mount(
+      <Image
+        id={imageId}
+        map={mapMock}
+        data={imageData}
+        options={imageOptions}
+        onError={onError}
+        onLoaded={onLoaded}
+      />
+    );
+
+    expect(mapMock.hasImage).toBeCalled();
+    expect(mapMock.addImage).toBeCalled();
+
+    expect(onLoaded).toBeCalled();
+    expect(onError).not.toBeCalled();
+  });
 });

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -73,13 +73,18 @@ class Image extends React.Component<Props> {
     }
   }
 
-  private addOrUpdateImage(map: Map, id: string, image: ImageDataType, options?: ImageOptionsType) {
+  private addOrUpdateImage(
+    map: Map,
+    id: string,
+    image: ImageDataType,
+    options?: ImageOptionsType
+  ) {
     if (map.hasImage(id)) {
       // updateImage is not a part of mapbox typings, but is a part of the libary
       // https://docs.mapbox.com/mapbox-gl-js/api/#map#updateimage
       if ('updateImage' in map) {
         // @ts-ignore
-        map.updateImage(id, image)
+        map.updateImage(id, image);
       }
     } else {
       map.addImage(id, image, options);

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -54,7 +54,8 @@ class Image extends React.Component<Props> {
     const { map, id, url, data, options, onError } = props;
 
     if (data) {
-      map.addImage(id, data, options);
+      // map.addImage(id, data, options);
+      this.addOrUpdateImage(map, id, data, options);
       this.loaded();
     } else if (url) {
       map.loadImage(url, (error: Error | undefined, image: ImageDataType) => {
@@ -65,9 +66,23 @@ class Image extends React.Component<Props> {
 
           return;
         }
-        map.addImage(id, image, options);
+        this.addOrUpdateImage(map, id, image, options);
+        // map.addImage(id, image, options);
         this.loaded();
       });
+    }
+  }
+
+  private addOrUpdateImage(map: Map, id: string, image: ImageDataType, options?: ImageOptionsType) {
+    if (map.hasImage(id)) {
+      // updateImage is not a part of mapbox typings, but is a part of the libary
+      // https://docs.mapbox.com/mapbox-gl-js/api/#map#updateimage
+      if ('updateImage' in map) {
+        // @ts-ignore
+        map.updateImage(id, image)
+      }
+    } else {
+      map.addImage(id, image, options);
     }
   }
 


### PR DESCRIPTION
If an image id has already been added to the map, existing functionality does not check for the image. This generates a non-fatal error.

Check for existing image added, will update image instead.

Note: map.updateImage does not accept image options, so those will not be updated.