### PR TITLE
WIP: feature: Adding support for LngLatBounds in fitBounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+.idea
 
 vendor/
 lib/

--- a/docs/API.md
+++ b/docs/API.md
@@ -60,7 +60,7 @@ const Map = ReactMapboxGl({
 * **zoom** _(Default: `[11]`)_: `[number]` Zoom level of the map at initialisation wrapped in an array.
   * Check for reference equality between the previous value of zoom and the new one in order to update it or not.
 * **maxBounds** : `LngLatBounds | number[][]` If set, the map is constrained to the given bounds [SouthWest, NorthEast]
-* **fitBounds** : `[[number, number], [number, number]]` If set, the map will center on the given coordinates, [fitBounds](https://www.mapbox.com/mapbox-gl-js/api/#Map#fitBounds)
+* **fitBounds** : `[[number, number], [number, number]] | mapboxgl.LngLatBounds` If set, the map will center on the given coordinates, [fitBounds](https://www.mapbox.com/mapbox-gl-js/api/#Map#fitBounds)
 * **fitBoundsOptions** : `object` Options for [fitBounds](https://www.mapbox.com/mapbox-gl-js/api/#Map#fitBounds)
 * **bearing**: `[number]` Bearing (rotation) of the map at initialisation measured in degrees counter-clockwise from north.
   * Check the previous value and the new one, if the value changed update the bearing value [flyTo](https://www.mapbox.com/mapbox-gl-js/api/#Map.flyTo)

--- a/src/map-events.tsx
+++ b/src/map-events.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import * as MapboxGl from 'mapbox-gl';
 
 export type MapEvent = (


### PR DESCRIPTION
Mapbox API supports multiple argument types for the `fitBounds` method.

1. `[[1, 2], [3, 4]]`: https://docs.mapbox.com/mapbox-gl-js/example/fitbounds/
1. `new LngLatBounds([1, 2], [3, 4])`: https://docs.mapbox.com/mapbox-gl-js/example/zoomto-linestring/

This PR adds the functionality for `new LngLatBounds([1, 2], [3, 4])` to be passed into the `fitBounds` method. 

It tackles the two areas of where fitBounds is used within `react-mapbox-gl`:

1. `the.calcCenter` that is called within `componentDidMount()`.
1. `fitBounds` prop updates within `UNSAFE_componentWillReceiveProps()`.