### PR TITLE
Renamed 'style' to 'mapStyle' on MapProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const Map = ReactMapboxGl({
 
 // in render()
 <Map
-  style="mapbox://styles/mapbox/streets-v9"
+  mapStyle="mapbox://styles/mapbox/streets-v9"
   containerStyle={{
     height: '100vh',
     width: '100vw'

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const Map = ReactMapboxGl({
 // in render()
 <Map
   mapStyle="mapbox://styles/mapbox/streets-v9"
-  containerStyle={{
+  style={{
     height: '100vh',
     width: '100vw'
   }}

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,7 +17,7 @@ const Map = ReactMapboxGl({
   accessToken: "pk.eyJ1IjoiZmFicmljOCIsImEiOiJjaWc5aTV1ZzUwMDJwdzJrb2w0dXRmc2d0In0.p6GGlfyV-WksaDV_KdN27A"
 });
 
-<Map style="mapbox://styles/mapbox/streets-v8"/>
+<Map mapStyle="mapbox://styles/mapbox/streets-v8"/>
 ```
 
 ### Factory parameters
@@ -52,7 +52,7 @@ const Map = ReactMapboxGl({
 
 ### Component Properties
 
-- **style** _(required)_ : `string | object` Mapbox map style, if changed, the style will be updated using `setStyle`.
+- **mapStyle** _(required)_ : `string | object` Mapbox map style, if changed, the style will be updated using `setStyle`.
 - **onStyleLoad**: `(map, loadEvent) => void` called with the Mapbox Map instance when the `load` event is fired. You can use the callback's first argument to then interact with the Mapbox API.
 - **center** _(Default: `[ -0.2416815, 51.5285582 ]`)_: `[number, number]` Center the map at the position at initialisation
   - Must be in longitude, latitude coordinate order (as opposed to latitude, longitude) to match GeoJSON (source: https://www.mapbox.com/mapbox-gl-js/api/#lnglat).
@@ -65,7 +65,7 @@ const Map = ReactMapboxGl({
 - **bearing**: `[number]` Bearing (rotation) of the map at initialisation measured in degrees counter-clockwise from north.
   - Check the previous value and the new one, if the value changed update the bearing value [flyTo](https://www.mapbox.com/mapbox-gl-js/api/#Map.flyTo)
 - **pitch**: `[number]` Pitch (tilt) of the map at initialisation, range : `0 - 60`
-- **containerStyle** : `object` The style of the container of the map passed as an object
+- **style** : `object` The style of the container of the map passed as an object
 - **className** : `string` ClassName passed down to the container div
 - **movingMethod** _(Default: `flyTo`)_: `string` define the method used when changing the center or zoom position. Possible value :
   - `jumpTo`
@@ -572,7 +572,7 @@ import ReactMapboxGL, { MapContext } from 'react-mapbox-gl';
 const Map = ReactMapboxGL({ /* factory options */ });
 
 const MyMap = () => (
-  <Map style="your-style-here">
+  <Map mapStyle="your-style-here">
     <MapContext.Consumer>
       {(map) => {
         // use `map` here

--- a/example/src/demos/allShapes.tsx
+++ b/example/src/demos/allShapes.tsx
@@ -29,7 +29,7 @@ const mappedRoute = route.points.map(
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -117,8 +117,8 @@ class AllShapes extends React.Component<Props, State> {
   public render() {
     return (
       <Map
-        style={mapData}
-        containerStyle={mapStyle}
+        mapStyle={mapData}
+        style={mapContainerStyle}
         // tslint:disable-next-line:jsx-no-lambda
         onStyleLoad={this.onStyleLoad}
         center={this.state.center}

--- a/example/src/demos/geojsonLayer.tsx
+++ b/example/src/demos/geojsonLayer.tsx
@@ -9,7 +9,7 @@ const geojson = require('./geojson.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -50,9 +50,9 @@ class GeoJsonLayer extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <GeoJSONLayer

--- a/example/src/demos/heatmap.tsx
+++ b/example/src/demos/heatmap.tsx
@@ -8,7 +8,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -66,9 +66,9 @@ export default class Heatmap extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <Layer type="heatmap" paint={layerPaint}>

--- a/example/src/demos/htmlCluster.tsx
+++ b/example/src/demos/htmlCluster.tsx
@@ -9,7 +9,7 @@ const falls = require('./falls.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -118,11 +118,11 @@ class HtmlCluster extends React.Component<Props, State> {
 
     return (
       <Map
-        style={outdoor}
+        mapStyle={outdoor}
         zoom={this.zoom}
         onStyleLoad={this.onStyleLoad}
         onMove={this.onMove}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         renderChildrenInPortal={true}
       >
         <Cluster ClusterMarkerFactory={this.clusterMarker}>

--- a/example/src/demos/htmlFeatures.tsx
+++ b/example/src/demos/htmlFeatures.tsx
@@ -26,7 +26,7 @@ const Mark = styled.div`
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   width: '100%',
   height: '100%'
 };
@@ -112,8 +112,8 @@ class HtmlFeatures extends React.Component<Props, State> {
           options={options}
         />
         <Map
-          style={styles.light}
-          containerStyle={mapStyle}
+          mapStyle={styles.light}
+          style={mapContainerStyle}
           center={center}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/londonCycle.tsx
+++ b/example/src/demos/londonCycle.tsx
@@ -14,7 +14,7 @@ const Mapbox = ReactMapboxGl({
   accessToken: token
 });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -99,14 +99,14 @@ export default class LondonCycle extends React.Component<Props, State> {
 
     return (
       <Mapbox
-        style={styles.londonCycle}
+        mapStyle={styles.londonCycle}
         onStyleLoad={this.onStyleLoad}
         fitBounds={fitBounds}
         maxBounds={maxBounds}
         center={center}
         zoom={zoom}
         onDrag={this.onDrag}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         flyToOptions={flyToOptions}
       >
         <Layer type="symbol" id="marker" layout={layoutLayer} images={images}>

--- a/example/src/demos/raws/allShapes.raw
+++ b/example/src/demos/raws/allShapes.raw
@@ -29,7 +29,7 @@ const mappedRoute = route.points.map(
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -117,8 +117,8 @@ class AllShapes extends React.Component<Props, State> {
   public render() {
     return (
       <Map
-        style={mapData}
-        containerStyle={mapStyle}
+        mapStyle={mapData}
+        style={mapContainerStyle}
         // tslint:disable-next-line:jsx-no-lambda
         onStyleLoad={this.onStyleLoad}
         center={this.state.center}

--- a/example/src/demos/raws/geojsonLayer.raw
+++ b/example/src/demos/raws/geojsonLayer.raw
@@ -9,7 +9,7 @@ const geojson = require('./geojson.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -50,9 +50,9 @@ class GeoJsonLayer extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <GeoJSONLayer

--- a/example/src/demos/raws/heatmap.raw
+++ b/example/src/demos/raws/heatmap.raw
@@ -8,7 +8,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -66,9 +66,9 @@ export default class Heatmap extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.dark}
+        mapStyle={styles.dark}
         center={this.center}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
       >
         <Layer type="heatmap" paint={layerPaint}>

--- a/example/src/demos/raws/htmlCluster.raw
+++ b/example/src/demos/raws/htmlCluster.raw
@@ -9,7 +9,7 @@ const falls = require('./falls.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -118,11 +118,11 @@ class HtmlCluster extends React.Component<Props, State> {
 
     return (
       <Map
-        style={outdoor}
+        mapStyle={outdoor}
         zoom={this.zoom}
         onStyleLoad={this.onStyleLoad}
         onMove={this.onMove}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         renderChildrenInPortal={true}
       >
         <Cluster ClusterMarkerFactory={this.clusterMarker}>

--- a/example/src/demos/raws/htmlFeatures.raw
+++ b/example/src/demos/raws/htmlFeatures.raw
@@ -26,7 +26,7 @@ const Mark = styled.div`
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   width: '100%',
   height: '100%'
 };
@@ -112,8 +112,8 @@ class HtmlFeatures extends React.Component<Props, State> {
           options={options}
         />
         <Map
-          style={styles.light}
-          containerStyle={mapStyle}
+          mapStyle={styles.light}
+          style={mapContainerStyle}
           center={center}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/raws/londonCycle.raw
+++ b/example/src/demos/raws/londonCycle.raw
@@ -14,7 +14,7 @@ const Mapbox = ReactMapboxGl({
   accessToken: token
 });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -99,14 +99,14 @@ export default class LondonCycle extends React.Component<Props, State> {
 
     return (
       <Mapbox
-        style={styles.londonCycle}
+        mapStyle={styles.londonCycle}
         onStyleLoad={this.onStyleLoad}
         fitBounds={fitBounds}
         maxBounds={maxBounds}
         center={center}
         zoom={zoom}
         onDrag={this.onDrag}
-        containerStyle={mapStyle}
+        style={mapContainerStyle}
         flyToOptions={flyToOptions}
       >
         <Layer type="symbol" id="marker" layout={layoutLayer} images={images}>

--- a/example/src/demos/raws/switchStyle.raw
+++ b/example/src/demos/raws/switchStyle.raw
@@ -45,7 +45,7 @@ const BottomBar = styled.div`
   align-items: center;
 `;
 
-const mapStyle = {
+const mapContainerStyle = {
   height: '100%',
   width: '100%'
 };
@@ -165,8 +165,8 @@ class StyleUpdate extends React.Component<Props, State> {
     return (
       <Container>
         <Map
-          style={styles[styleKey]}
-          containerStyle={mapStyle}
+          mapStyle={styles[styleKey]}
+          style={mapContainerStyle}
           center={mapCenter}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/raws/threeDMap.raw
+++ b/example/src/demos/raws/threeDMap.raw
@@ -6,7 +6,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -43,8 +43,8 @@ class ThreeDMap extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.light}
-        containerStyle={mapStyle}
+        mapStyle={styles.light}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
         zoom={this.zoom}
         center={this.center}

--- a/example/src/demos/switchStyle.tsx
+++ b/example/src/demos/switchStyle.tsx
@@ -45,7 +45,7 @@ const BottomBar = styled.div`
   align-items: center;
 `;
 
-const mapStyle = {
+const mapContainerStyle = {
   height: '100%',
   width: '100%'
 };
@@ -165,8 +165,8 @@ class StyleUpdate extends React.Component<Props, State> {
     return (
       <Container>
         <Map
-          style={styles[styleKey]}
-          containerStyle={mapStyle}
+          mapStyle={styles[styleKey]}
+          style={mapContainerStyle}
           center={mapCenter}
           onStyleLoad={this.onStyleLoad}
         >

--- a/example/src/demos/threeDMap.tsx
+++ b/example/src/demos/threeDMap.tsx
@@ -6,7 +6,7 @@ const { token, styles } = require('./config.json');
 
 const Map = ReactMapboxGl({ accessToken: token });
 
-const mapStyle = {
+const mapContainerStyle = {
   flex: 1
 };
 
@@ -43,8 +43,8 @@ class ThreeDMap extends React.Component<Props> {
   public render() {
     return (
       <Map
-        style={styles.light}
-        containerStyle={mapStyle}
+        mapStyle={styles.light}
+        style={mapContainerStyle}
         onStyleLoad={this.onStyleLoad}
         zoom={this.zoom}
         center={this.center}

--- a/src/__tests__/map.test.tsx
+++ b/src/__tests__/map.test.tsx
@@ -34,7 +34,7 @@ describe('Map', () => {
       accessToken: '',
       mapInstance: getMock() as any
     });
-    mount(<MapboxMap style="" />);
+    mount(<MapboxMap mapStyle="" />);
   });
 
   it('Should call fitBounds with the right parameters', () => {
@@ -47,7 +47,7 @@ describe('Map', () => {
 
     mount(
       <MapboxMap
-        style=""
+        mapStyle=""
         fitBounds={fitBoundsValues}
         fitBoundsOptions={fitBoundsOptions}
       />
@@ -74,7 +74,7 @@ describe('Map', () => {
 
     const wrapper = mount(
       <MapboxMap
-        style=""
+        mapStyle=""
         fitBounds={fitBoundsValues}
         fitBoundsOptions={fitBoundsOptions}
       />
@@ -90,7 +90,7 @@ describe('Map', () => {
     const mockMap = getMock() as any;
     const MapboxMap = ReactMapboxGl({ accessToken: '', mapInstance: mockMap });
 
-    mount(<MapboxMap style="" fitBounds={fitBoundsValues} />);
+    mount(<MapboxMap mapStyle="" fitBounds={fitBoundsValues} />);
 
     // tslint:disable-next-line:no-any
     const lastCall: any = mockMap.mock.calls[mockMap.mock.calls.length - 1];
@@ -103,7 +103,7 @@ describe('Map', () => {
       mapInstance: getMock() as any
     });
 
-    mount(<MapboxMap style="" onStyleLoad={jest.fn()} />);
+    mount(<MapboxMap mapStyle="" onStyleLoad={jest.fn()} />);
 
     expect(mockon).toBeCalledWith('load', jasmine.any(Function));
   });
@@ -118,7 +118,7 @@ describe('Map', () => {
       }) as any
     });
 
-    const wrapper = mount(<MapboxMap style="" center={[1, 2]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" center={[1, 2]} />);
 
     wrapper.setProps({ center });
 
@@ -138,7 +138,7 @@ describe('Map', () => {
       }) as any
     });
 
-    const wrapper = mount(<MapboxMap style="" />);
+    const wrapper = mount(<MapboxMap mapStyle="" />);
     wrapper.setProps({ maxBounds: maxBoundsProps });
 
     expect(mockMaxBounds).toBeCalledWith(maxBoundsProps);
@@ -156,7 +156,7 @@ describe('Map', () => {
 
     const zoom: [number] = [3];
 
-    const wrapper = mount(<MapboxMap style="" zoom={zoom} />);
+    const wrapper = mount(<MapboxMap mapStyle="" zoom={zoom} />);
 
     wrapper.setProps({ zoom });
 
@@ -172,7 +172,7 @@ describe('Map', () => {
       }) as any
     });
 
-    const wrapper = mount(<MapboxMap style="" zoom={[1]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" zoom={[1]} />);
 
     wrapper.setProps({ zoom: [1] });
 
@@ -190,7 +190,7 @@ describe('Map', () => {
     });
     const bearing: [number] = [3];
 
-    const wrapper = mount(<MapboxMap style="" bearing={bearing} />);
+    const wrapper = mount(<MapboxMap mapStyle="" bearing={bearing} />);
 
     wrapper.setProps({ bearing });
 
@@ -206,7 +206,7 @@ describe('Map', () => {
       }) as any
     });
 
-    const wrapper = mount(<MapboxMap style="" bearing={[1]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" bearing={[1]} />);
 
     wrapper.setProps({ bearing: [1] });
 
@@ -224,7 +224,7 @@ describe('Map', () => {
     });
     const pitch: [number] = [3];
 
-    const wrapper = mount(<MapboxMap style="" pitch={pitch} />);
+    const wrapper = mount(<MapboxMap mapStyle="" pitch={pitch} />);
 
     wrapper.setProps({ pitch });
 
@@ -240,7 +240,7 @@ describe('Map', () => {
       }) as any
     });
 
-    const wrapper = mount(<MapboxMap style="" pitch={[1]} />);
+    const wrapper = mount(<MapboxMap mapStyle="" pitch={[1]} />);
 
     wrapper.setProps({ pitch: [1] });
 
@@ -266,7 +266,7 @@ describe('Map', () => {
 
     const wrapper = mount(
       <MapboxMap
-        style=""
+        mapStyle=""
         zoom={zoom}
         flyToOptions={flyToOptions}
         animationOptions={animationOptions}

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -45,7 +45,7 @@ export interface FlyToOptions {
 
 // React Props updated between re-render
 export interface Props {
-  style: string | MapboxGl.Style;
+  mapStyle: string | MapboxGl.Style;
   center?: [number, number];
   zoom?: [number];
   maxBounds?: MapboxGl.LngLatBounds | FitBounds;
@@ -178,7 +178,7 @@ const ReactMapboxFactory = ({
 
     public componentDidMount() {
       const {
-        style,
+        mapStyle,
         onStyleLoad,
         center,
         pitch,
@@ -214,7 +214,7 @@ const ReactMapboxFactory = ({
           fitBounds && center === defaultCenter
             ? this.calcCenter(fitBounds)
             : center,
-        style,
+        mapStyle,
         scrollZoom,
         attributionControl,
         customAttribution,
@@ -373,8 +373,8 @@ const ReactMapboxFactory = ({
         });
       }
 
-      if (!isEqual(prevProps.style, this.props.style)) {
-        map.setStyle(this.props.style);
+      if (!isEqual(prevProps.mapStyle, this.props.mapStyle)) {
+        map.setStyle(this.props.mapStyle);
       }
 
       return null;

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -53,7 +53,7 @@ export interface Props {
   fitBoundsOptions?: FitBoundsOptions;
   bearing?: [number];
   pitch?: [number];
-  containerStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
   className?: string;
   movingMethod?: 'jumpTo' | 'easeTo' | 'flyTo';
   animationOptions?: Partial<AnimationOptions>;
@@ -154,7 +154,7 @@ const ReactMapboxFactory = ({
       bearing: 0,
       movingMethod: defaultMovingMethod,
       pitch: 0,
-      containerStyle: {
+      style: {
         textAlign: 'left'
       }
     };
@@ -386,7 +386,7 @@ const ReactMapboxFactory = ({
 
     public render() {
       const {
-        containerStyle,
+        style,
         className,
         children,
         renderChildrenInPortal
@@ -405,7 +405,7 @@ const ReactMapboxFactory = ({
             <div
               ref={this.setRef}
               className={className}
-              style={{ ...containerStyle }}
+              style={{ ...style }}
             >
               {ready && container && createPortal(children, container)}
             </div>
@@ -418,7 +418,7 @@ const ReactMapboxFactory = ({
           <div
             ref={this.setRef}
             className={className}
-            style={{ ...containerStyle }}
+            style={{ ...style }}
           >
             {ready && children}
           </div>

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -385,12 +385,7 @@ const ReactMapboxFactory = ({
     };
 
     public render() {
-      const {
-        style,
-        className,
-        children,
-        renderChildrenInPortal
-      } = this.props;
+      const { style, className, children, renderChildrenInPortal } = this.props;
 
       const { ready, map } = this.state;
 
@@ -402,11 +397,7 @@ const ReactMapboxFactory = ({
 
         return (
           <MapContext.Provider value={map}>
-            <div
-              ref={this.setRef}
-              className={className}
-              style={{ ...style }}
-            >
+            <div ref={this.setRef} className={className} style={{ ...style }}>
               {ready && container && createPortal(children, container)}
             </div>
           </MapContext.Provider>
@@ -415,11 +406,7 @@ const ReactMapboxFactory = ({
 
       return (
         <MapContext.Provider value={map}>
-          <div
-            ref={this.setRef}
-            className={className}
-            style={{ ...style }}
-          >
+          <div ref={this.setRef} className={className} style={{ ...style }}>
             {ready && children}
           </div>
         </MapContext.Provider>


### PR DESCRIPTION
Closes #498 
Closes #785 
Related PR: #533

> Fixes #498
> ## Breaking Changes
> ### Component Properties
> 
>     * **style** → **mapStyle**
>       
>       * **style** has been renamed to **mapStyle** to avoid confusion with DOM styles.
> 
>     * **containerStyle** → **style**
>       
>       * **containerStyle** has been renamed to **style** to adhere to standard React convention.
>       * The **style** prop now controls the DOM styles for the container element.

 
https://github.com/alex3165/react-mapbox-gl/pull/533#issue-168717232