### PR TITLE
fix: GeoJSONLayer and data prop updating

### DIFF
--- a/src/geojson-layer.ts
+++ b/src/geojson-layer.ts
@@ -269,7 +269,7 @@ export class GeoJSONLayer extends React.Component<Props> {
       return;
     }
 
-    if (prevProps.data !== data) {
+    if (this.props.data !== data) {
       source.setData(this.props.data);
 
       this.source = {


### PR DESCRIPTION
Currently, when the data prop is updated, nothing changes, as the comparison is faulty (it compares in essence `prevProps.data` against itself).

This fixes it, allowing for the `data` prop to change on `GeoJSONLayer` and the underlying source then properly being updated.