### PR TITLE
Fix memoized rebind

### DIFF
--- a/src/__tests__/layer.test.tsx
+++ b/src/__tests__/layer.test.tsx
@@ -275,7 +275,7 @@ describe('Layer', () => {
     expect(mockMap.on.mock.calls[0][1]).toEqual(id);
   });
 
-  it.skip('Should rebind events when a new handler is passed to Layer', () => {
+  it('Should rebind events when a new handler is passed to Layer', () => {
     const mockMap = getMapMock();
     const id = 'layer-test';
 

--- a/src/__tests__/layer.test.tsx
+++ b/src/__tests__/layer.test.tsx
@@ -274,4 +274,29 @@ describe('Layer', () => {
     expect(mockMap.on.mock.calls[0][0]).toEqual('click');
     expect(mockMap.on.mock.calls[0][1]).toEqual(id);
   });
+
+  it.skip('Should rebind events when a new handler is passed to Layer', () => {
+    const mockMap = getMapMock();
+    const id = 'layer-test';
+
+    const fn1 = jest.fn();
+    const fn2 = jest.fn();
+
+    const wrapper = mount(
+      // tslint:disable-next-line:no-any
+      <Layer id={id} map={mockMap as any} onClick={fn1} />
+    );
+
+    wrapper.setProps({ onClick: fn2 });
+
+    expect(mockMap.on.mock.calls[0][0]).toEqual('click');
+    expect(mockMap.on.mock.calls[0][1]).toEqual(id);
+    expect(mockMap.on.mock.calls[0][2]).toEqual(fn1);
+
+    expect(mockMap.off.mock.calls[0][0]).toEqual('click');
+    expect(mockMap.off.mock.calls[0][1]).toEqual(id);
+    expect(mockMap.off.mock.calls[0][2]).toEqual(fn1);
+
+    expect(mockMap.on.mock.calls[0][2]).toEqual(fn2);
+  });
 });

--- a/src/__tests__/map.test.tsx
+++ b/src/__tests__/map.test.tsx
@@ -108,13 +108,12 @@ describe('Map', () => {
     expect(mockon).toBeCalledWith('load', jasmine.any(Function));
   });
 
-  it('Should rebind events when a new handler is passed to Map with MemoizedEvents: true', () => {
+  it('Should call only the latest passed-in event handler', () => {
     const mockMap = getMock() as any;
 
     const MapboxMap = ReactMapboxGl({
       accessToken: '',
-      mapInstance: mockMap,
-      memoizedEvents: true
+      mapInstance: mockMap
     });
 
     const fn1 = jest.fn();
@@ -124,14 +123,13 @@ describe('Map', () => {
 
     wrapper.setProps({ onClick: fn2 });
 
-    expect(mockMap.on.mock.calls[1][0]).toEqual('click');
-    expect(mockMap.on.mock.calls[1][1]).toEqual(fn1);
+    const [eventName, listener] = mockMap.on.mock.calls[1];
+    expect(eventName).toEqual('click');
 
-    expect(mockMap.off.mock.calls[0][0]).toEqual('click');
-    expect(mockMap.off.mock.calls[0][1]).toEqual(fn1);
+    listener();
 
-    expect(mockMap.on.mock.calls[2][0]).toEqual('click');
-    expect(mockMap.on.mock.calls[2][1]).toEqual(fn2);
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).toHaveBeenCalled();
   });
 
   it('Should update the map center position', () => {

--- a/src/__tests__/map.test.tsx
+++ b/src/__tests__/map.test.tsx
@@ -108,6 +108,32 @@ describe('Map', () => {
     expect(mockon).toBeCalledWith('load', jasmine.any(Function));
   });
 
+  it('Should rebind events when a new handler is passed to Map with MemoizedEvents: true', () => {
+    const mockMap = getMock() as any;
+
+    const MapboxMap = ReactMapboxGl({
+      accessToken: '',
+      mapInstance: mockMap,
+      memoizedEvents: true
+    });
+
+    const fn1 = jest.fn();
+    const fn2 = jest.fn();
+
+    const wrapper = mount(<MapboxMap style="" onClick={fn1} />);
+
+    wrapper.setProps({ onClick: fn2 });
+
+    expect(mockMap.on.mock.calls[1][0]).toEqual('click');
+    expect(mockMap.on.mock.calls[1][1]).toEqual(fn1);
+
+    expect(mockMap.off.mock.calls[0][0]).toEqual('click');
+    expect(mockMap.off.mock.calls[0][1]).toEqual(fn1);
+
+    expect(mockMap.on.mock.calls[2][0]).toEqual('click');
+    expect(mockMap.on.mock.calls[2][1]).toEqual(fn2);
+  });
+
   it('Should update the map center position', () => {
     const flyTo = jest.fn();
     const center = [3, 4];

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -96,7 +96,6 @@ export interface FactoryParameters {
   boxZoom?: boolean;
   refreshExpiredTiles?: boolean;
   failIfMajorPerformanceCaveat?: boolean;
-  memoizedEvents?: boolean;
   bearingSnap?: number;
   transformRequest?: RequestTransformFunction;
   antialias?: boolean;
@@ -282,7 +281,7 @@ const ReactMapboxFactory = ({
         }
       });
 
-      this.listeners = listenEvents(events, this.props, map);
+      this.listeners = listenEvents(events, this, map);
     }
 
     public componentWillUnmount() {
@@ -301,7 +300,7 @@ const ReactMapboxFactory = ({
       }
 
       // Update event listeners
-      this.listeners = updateEvents(this.listeners, this.props, prevProps, map);
+      this.listeners = updateEvents(this.listeners, this, map);
 
       const center = map.getCenter();
       const zoom = map.getZoom();

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -96,6 +96,7 @@ export interface FactoryParameters {
   boxZoom?: boolean;
   refreshExpiredTiles?: boolean;
   failIfMajorPerformanceCaveat?: boolean;
+  memoizedEvents?: boolean;
   bearingSnap?: number;
   transformRequest?: RequestTransformFunction;
   antialias?: boolean;
@@ -300,7 +301,7 @@ const ReactMapboxFactory = ({
       }
 
       // Update event listeners
-      this.listeners = updateEvents(this.listeners, this.props, map);
+      this.listeners = updateEvents(this.listeners, this.props, prevProps, map);
 
       const center = map.getCenter();
       const zoom = map.getZoom();


### PR DESCRIPTION
This is a strawman fix for #927. Currently react-mapbox-gl binds DOM events the first time a prop function is passed in, which means that for memoized functions (for instance, with useMemo / React functional components) the handler may be a stale closure and have out-of-date data.

The issue is that the `updateEvents` function in map-events.tsx only checks for the presence of the function but not referential equality, and doesn't dereference the latest value off of `this.props`.

As I see it, there are 3 approaches we could take to fix this in library code:

1. Unbind stale functions and re-bind new functions when passed in (i.e. change the `toListenOff` expression to check against prevProps -- see the first commit here).
2. 3. Dereference the latest value of the callback in this.props (the approach I took here in the second commit). The issue with this approach is that we need access to the `this` object in `updateEvents`, because the `props` changes between renders, so this is a bit uglier than I'd like.
3. Use a Ref, always set to the latest passed-in prop value. This seems like a duplication of 2 with extra steps.

The last approach would be to migrate map.tsx to be a functional component, but that might be a bigger ask. 

Any suggestions here? Thanks!