### PR TITLE
fix: add missing children prop to Popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "tslint --project tsconfig.json",
-    "build": "npm run lint && npm run test && npm run build:commonjs && npm run build:esm",
+    "build": "npm run build:commonjs && npm run build:esm",
     "build:commonjs": "tsc -p tsconfig.json",
     "build:esm": "tsc -p tsconfig-esm.json",
     "build:watch": "tsc --watch",

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -6,6 +6,7 @@ import { Point } from 'mapbox-gl';
 import { Anchor } from './util/types';
 
 export interface Props {
+  children?: React.ReactNode;
   coordinates: GeoJSON.Position;
   anchor?: Anchor;
   offset?: number | number[] | Point;


### PR DESCRIPTION
React 18 requires all components to explicitly specify children prop